### PR TITLE
feat: 新增 email 認證功能、重發認證信，客製化認證 email 頁面  (附 i18n 中/英文)

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,4 +1,7 @@
-GOOGLE_APP_ID=your_facebook_app_id
-GOOGLE_APP_SECRET=your_facebook_app_secret
-FACEBOOK_APP_ID=your_facebook_app_id
-FACEBOOK_APP_SECRET=your_facebook_app_secret
+GOOGLE_CLIENT_ID = your_google_client_id
+GOOGLE_CLIENT_SECRET = your_google_client_secret
+FACEBOOK_APP_ID = your_facebook_app_id
+FACEBOOK_APP_SECRET = your_facebook_app_secret
+
+MAIL_USER_NAME = your_mail_user
+MAIL_PASSWORD = your_mail_password

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 # or operating system, you probably want to add a global ignore instead:
 #   git config --global core.excludesfile '~/.gitignore_global'
 
+# Ignore vscode setting
+/.vscode/.json
+
 # Ignore bundler config.
 /.bundle
 

--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,8 @@ group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'dotenv-rails'
   gem "debug", platforms: %i[ mri mingw x64_mingw ]
+  gem "rspec-rails", "~> 6.0"
+  gem "letter_opener", "~> 1.8"
 end
 
 group :development do
@@ -55,5 +57,6 @@ group :test do
   gem "selenium-webdriver"
   gem "webdrivers"
 end
+
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,7 @@ GEM
     dotenv-rails (2.8.1)
       dotenv (= 2.8.1)
       railties (>= 3.2)
+    diff-lcs (1.5.0)
     erubi (1.12.0)
     faraday (2.7.10)
       faraday-net_http (>= 2.0, < 3.1)
@@ -118,6 +119,10 @@ GEM
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     jwt (2.7.1)
+    launchy (2.5.2)
+      addressable (~> 2.8)
+    letter_opener (1.8.1)
+      launchy (>= 2.2, < 3)
     loofah (2.21.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -217,6 +222,23 @@ GEM
       railties (>= 5.2)
     rexml (3.2.6)
     ruby2_keywords (0.0.5)
+    rspec-core (3.12.2)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.3)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.6)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-rails (6.0.3)
+      actionpack (>= 6.1)
+      activesupport (>= 6.1)
+      railties (>= 6.1)
+      rspec-core (~> 3.12)
+      rspec-expectations (~> 3.12)
+      rspec-mocks (~> 3.12)
+      rspec-support (~> 3.12)
+    rspec-support (3.12.1)
     rubyzip (2.3.2)
     selenium-webdriver (4.10.0)
       rexml (~> 3.2, >= 3.2.5)
@@ -275,6 +297,7 @@ DEPENDENCIES
   dotenv-rails
   importmap-rails
   jbuilder
+  letter_opener (~> 1.8)
   omniauth (~> 2.1)
   omniauth-facebook
   omniauth-google-oauth2
@@ -282,6 +305,7 @@ DEPENDENCIES
   pg (~> 1.1)
   puma (~> 5.0)
   rails (~> 7.0.6)
+  rspec-rails (~> 6.0)
   selenium-webdriver
   sprockets-rails
   stimulus-rails

--- a/app/controllers/Users/confirmations_controller.rb
+++ b/app/controllers/Users/confirmations_controller.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class Users::ConfirmationsController < Devise::ConfirmationsController
+  # GET /resource/confirmation/new
+  def new
+    super
+  end
+
+  # POST /resource/confirmation
+  # def create
+  #   super
+  # end
+
+  # GET /resource/confirmation?confirmation_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after resending confirmation instructions.
+  # def after_resending_confirmation_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+
+  # The path used after confirmation.
+  def after_confirmation_path_for(resource_name, resource)
+    sign_in(resource)
+    super(resource_name, resource)
+  end
+end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,5 +1,4 @@
 class UserMailer < Devise::Mailer
-  helper :application
   include Devise::Controllers::UrlHelpers
   default template_path: 'users/mailer'
 

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,0 +1,13 @@
+class UserMailer < Devise::Mailer
+  helper :application
+  include Devise::Controllers::UrlHelpers
+  default template_path: 'users/mailer'
+
+  def confirmation_instructions(record, token, opt={})
+    headers["Custom-header"] = "Bar"
+    opt[:subject] = "請驗證您的Email信箱"
+    opt[:from] = "noreply@joband.co"
+    opt[:reply_to] = "support@joband.co"
+    super
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,8 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable, :trackable and 
+  # :lockable, :timeoutable, :trackable and 
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable, 
+         :recoverable, :rememberable, :validatable, :confirmable,
          :omniauthable, omniauth_providers: [:facebook, :google_oauth2]
 
   def self.find_for_google_oauth2(access_token, signed_in_resource=nil)

--- a/app/views/user_mailer/confirmation_instructions.html.erb
+++ b/app/views/user_mailer/confirmation_instructions.html.erb
@@ -1,0 +1,46 @@
+<div style="background:#f9f9f9;padding:40px 0;margin:10px 0;border-bottom:1px solid #efefef">
+  <table style="border-spacing:0;border-collapse:collapse;width:100%;vertical-align:top;max-width:640px;margin:0 auto;padding:0;font-size:15px;font-family:Arial,Helvetica">
+    <tbody>
+      <tr>
+        <td>
+          <table style="border-spacing:0;border-collapse:collapse;width:100%;vertical-align:top;margin:20px 0;padding:0;font-size:14px">
+            <tbody>
+              <tr>
+                <td style="padding-bottom:16px">
+                  <span style="font-size:28px"><b>歡迎加入 JoBand, <%= @email %>!</b></span>
+                </td>
+              </tr>
+              <tr>
+                <td style="padding-bottom:12px">
+                  <span style="font-size:14px">如果是您本人註冊，請按一下以下連結以驗證您的電子郵件：</span>
+                </td>
+              </tr>
+              <tr>
+                <td style="padding-bottom:16px;text-align:center">
+                  <%= link_to '確認是我的電子郵件', confirmation_url(@resource, confirmation_token: @token), class: "blink", style: "color:#fff;text-decoration:none;display:inline-block;color:#fff;border-radius:4px;border-bottom-width:2px;border-bottom-color:#00a462;border-bottom-style:solid;background:#00cb6f;padding:15px 40px;margin:10px auto;font-size:18px", target:"_blank" %>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <div style="text-align:center"></div>
+                </td>
+              </tr>
+              <tr>
+                <td style="padding-bottom:12px">
+                  <span style="font-size:14px">如果不是您註冊的，請刪除此信件。</span>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <span style="font-size:14px;display:block">
+                    <br>Cheers,<br>JoBand 開發團隊
+                  </span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/app/views/users/confirmations/new.html.erb
+++ b/app/views/users/confirmations/new.html.erb
@@ -1,0 +1,23 @@
+<div class="bg-dark rounded-md px-10 py-5 flex-wrap w-60%">
+  <header class="block w-100% text-white">
+    <h2 class="h2"><%= t("user.resend_confirm_email")%></h2>
+  </header>
+
+  <div class="block mx-auto w-100%">
+    <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
+      <%= render "users/shared/error_messages", resource: resource %>
+
+      <div class="field my-2">
+        <%= f.label :email, class: "text-white" %><br />
+        <%= f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email), placeholder: "email@example.com" %>
+      </div>
+
+      <div class="actions">
+        <%= f.submit t("user.resend_button"), class: "btn" %>
+      </div>
+    <% end %>
+  </div>
+  <div class="aside-info text-white">
+    <%= render "users/shared/links" %>
+  </div>
+</div>

--- a/app/views/users/shared/_links.html.erb
+++ b/app/views/users/shared/_links.html.erb
@@ -11,7 +11,7 @@
 <% end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
+  <%= link_to t("user.not_receive_confirm"), new_confirmation_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>

--- a/app/views/users/shared/_links.html.erb
+++ b/app/views/users/shared/_links.html.erb
@@ -11,7 +11,7 @@
 <% end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-  <%= link_to t("user.not_receive_confirm"), new_confirmation_path(resource_name) %><br />
+  <%= link_to t("user.not_receive_confirm"), new_confirmation_path(resource_name), class: "link" %><br />
 <% end %>
 
 <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -19,8 +19,6 @@ Rails.application.configure do
   # letter opener
   config.action_mailer.delivery_method = :letter_opener
   config.action_mailer.perform_deliveries = true
-
-  # Devise
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
   # Settings specified here will take precedence over those in config/application.rb.
 
@@ -58,7 +56,7 @@ Rails.application.configure do
   config.active_storage.service = :local
 
   # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
 
   config.action_mailer.perform_caching = false
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -2,6 +2,11 @@ require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
   
+  # letter opener
+  config.action_mailer.delivery_method = :letter_opener
+  config.action_mailer.perform_deliveries = true
+
+  # Devise
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
   # Settings specified here will take precedence over those in config/application.rb.
 
@@ -62,7 +67,7 @@ Rails.application.configure do
   config.assets.quiet = true
 
   # Raises error for missing translations.
-  # config.i18n.raise_on_missing_translations = true
+  config.i18n.raise_on_missing_translations = true
 
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -2,6 +2,20 @@ require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
   
+  # mail SMTP set
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address:              'smtp.mailgun.org',
+    port:                 587,
+    domain:               'joband.co',
+    user_name:            ENV['MAIL_USER_NAME'],
+    password:             ENV['MAIL_PASSWORD'],
+    authentication:       'plain',
+    enable_starttls_auto: true,
+    open_timeout:         5,
+    read_timeout:         5 
+  }
+
   # letter opener
   config.action_mailer.delivery_method = :letter_opener
   config.action_mailer.perform_deliveries = true

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -16,9 +16,6 @@ Devise.setup do |config|
   # config.parent_controller = 'DeviseController'
 
   # ==> Mailer Configuration
-  # Configure the e-mail address which will be shown in Devise::Mailer,
-  # note that it will be overwritten if you use your own mailer class
-  # with default "from" parameter.
   config.mailer_sender = 'noreply@joband.co'
 
   # Configure the class responsible to send e-mails.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,13 +1,5 @@
 # frozen_string_literal: true
 
-# Assuming you have not yet modified this file, each configuration option below
-# is set to its default value. Note that some are commented out while others
-# are not: uncommented lines are intended to protect your configuration from
-# breaking changes in upgrades (i.e., in the event that future versions of
-# Devise change the default values for those options).
-#
-# Use this hook to configure devise mailer, warden hooks and so forth.
-# Many of these configuration options can be set straight in your model.
 Devise.setup do |config|
 
   config.omniauth :facebook, ENV['FACEBOOK_APP_ID'], ENV['FACEBOOK_APP_SECRET'], scope: "public_profile,email", info_fields: "email,name"
@@ -27,10 +19,10 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = 'noreply@joband.co'
 
   # Configure the class responsible to send e-mails.
-  # config.mailer = 'Devise::Mailer'
+  config.mailer = 'UserMailer'
 
   # Configure the parent class responsible to send e-mails.
   # config.parent_mailer = 'ActionMailer::Base'
@@ -160,7 +152,7 @@ Devise.setup do |config|
   # initial account confirmation) to be applied. Requires additional unconfirmed_email
   # db field (see migrations). Until confirmed, new email is stored in
   # unconfirmed_email column, and copied to email column on successful confirmation.
-  config.reconfirmable = true
+  config.reconfirmable = false
 
   # Defines which key will be used when confirming an account
   # config.confirmation_keys = [:email]
@@ -181,11 +173,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 6..128
-
-  # Email regex used to validate email formats. It simply asserts that
-  # one (and only one) @ exists in the given string. This is mainly
-  # to give user feedback and not to assert the e-mail validity.
+  config.password_length = 8...16
   config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
 
   # ==> Configuration for :timeoutable

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,36 +1,3 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t "hello"
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t("hello") %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# The following keys must be escaped otherwise they will not be retrieved by
-# the default I18n backend:
-#
-# true, false, on, off, yes, no
-#
-# Instead, surround them with single quotes.
-#
-# en:
-#   "true": "foo"
-#
-# To learn more, please read the Rails Internationalization guide
-# available at https://guides.rubyonrails.org/i18n.html.
-
-# Additional translations at https://github.com/heartcombo/devise/wiki/I18n
-
 en:
   user:
     sign_up: "Sign Up"
@@ -38,12 +5,16 @@ en:
     min_password_placeholder: "8 characters minimum"
     password_confirmation: "Password confirmation"
     password_confirmation_placeholder: "Please confirmation your password again"
+    not_receive_confirm: "Didn't receive confirmation email?"
+    resend_confirm_email: "Resend confirmation Email"
+    resend_button: "Resend"
     login: "Log In"
     remember_me: "Remember me"
     forgot_password: "Forgot your password?"
     forgot_password_submit: "Send mail to reset password"
     not_yet: "Don’t have an account?"
     already: "Already a member?"
+
   devise:
     confirmations:
       confirmed: "Your email address has been successfully confirmed."

--- a/config/locales/tw.yml
+++ b/config/locales/tw.yml
@@ -5,12 +5,16 @@ tw:
     min_password_placeholder: "請輸入至少 8 字元"
     password_confirmation: "確認密碼"
     password_confirmation_placeholder: "請再次確認密碼"
+    not_receive_confirm: "沒有收到認證信嗎？"
+    resend_confirm_email: "重新發送認證信"
+    resend_button: "重新發送"
     login: "登入"
     remember_me: "記住我"
     forgot_password: "忘記密碼？"
     forgot_password_submit: "發送重設密碼信件"
     not_yet: "還不是會員嗎？"
     already: "已經是會員了嗎？"
+    
   devise:
     confirmations:
       confirmed: "您的帳號已通過驗證，現在您已成功登入。"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
     registrations: "users/registrations",
     passwords: "users/passwords",
     omniauth_callbacks: "users/omniauth_callbacks"
+    confirmations: "users/confirmations"
   }
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
     sessions: 'users/sessions',
     registrations: "users/registrations",
     passwords: "users/passwords",
-    omniauth_callbacks: "users/omniauth_callbacks"
+    omniauth_callbacks: "users/omniauth_callbacks",
     confirmations: "users/confirmations"
   }
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html

--- a/db/migrate/20230812152932_add_confirmable_to_devise.rb
+++ b/db/migrate/20230812152932_add_confirmable_to_devise.rb
@@ -5,7 +5,6 @@ class AddConfirmableToDevise < ActiveRecord::Migration[7.0]
     add_column :users, :confirmation_sent_at, :datetime
 
     add_index  :users, :confirmation_token, unique: true
-    User.update_all confirmed_at: DateTime.now
   end
 
   def down

--- a/db/migrate/20230812152932_add_confirmable_to_devise.rb
+++ b/db/migrate/20230812152932_add_confirmable_to_devise.rb
@@ -1,0 +1,15 @@
+class AddConfirmableToDevise < ActiveRecord::Migration[7.0]
+  def up
+    add_column :users, :confirmation_token, :string
+    add_column :users, :confirmed_at, :datetime
+    add_column :users, :confirmation_sent_at, :datetime
+
+    add_index  :users, :confirmation_token, unique: true
+    User.update_all confirmed_at: DateTime.now
+  end
+
+  def down
+    remove_index :users, :confirmation_token
+    remove_columns :users, :confirmation_token, :confirmed_at, :confirmation_sent_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,16 +1,4 @@
-# This file is auto-generated from the current state of the database. Instead
-# of editing this file, please use the migrations feature of Active Record to
-# incrementally modify your database, and then regenerate this schema definition.
-#
-# This file is the source Rails uses to define your schema when running `bin/rails
-# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
-# be faster and is potentially less error prone than running all of your
-# migrations from scratch. Old migrations may fail to apply correctly if those
-# migrations use external dependencies or application code.
-#
-# It's strongly recommended that you check this file into your version control system.
-
-ActiveRecord::Schema[7.0].define(version: 2023_08_11_025201) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_12_152932) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -27,6 +15,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_11_025201) do
     t.string "fb_token"
     t.string "google_uid"
     t.string "google_token"
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -23,13 +23,13 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_12_152932) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "confirmation_token"
-    t.datetime "confirmed_at"
-    t.datetime "confirmation_sent_at"
     t.string "fb_uid"
     t.string "fb_token"
     t.string "google_uid"
     t.string "google_token"
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,3 +1,15 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
 ActiveRecord::Schema[7.0].define(version: 2023_08_12_152932) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -11,13 +23,13 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_12_152932) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
     t.string "fb_uid"
     t.string "fb_token"
     t.string "google_uid"
     t.string "google_token"
-    t.string "confirmation_token"
-    t.datetime "confirmed_at"
-    t.datetime "confirmation_sent_at"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/spec/mailers/previews/user_preview.rb
+++ b/spec/mailers/previews/user_preview.rb
@@ -1,0 +1,14 @@
+# Preview all emails at http://localhost:3000/rails/mailers/user
+class UserPreview < ActionMailer::Preview
+  def confirmation_instructions
+    UserMailer.confirmation_instructions(User.first, "faketoken", {})
+  end
+
+  def reset_password_instructions
+    UserMailer.reset_password_instructions(User.first, "faketoken", {})
+  end
+
+  def unlock_instructions
+    UserMailer.unlock_instructions(User.first, "faketoken", {})
+  end
+end

--- a/spec/mailers/user_spec.rb
+++ b/spec/mailers/user_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe UserMailer, type: :mailer do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
如標題所示，共分七次 小commit

先說結果：開發環境成功，letter_opener 有出來，mailgun 已設定好，不過看 log 好像還是一直從我的本機發送，我猜測是 dev環境 letter_opener 的設定原因，詳情明天追問 @zhanjian0217 

1. bundle add letter_opener ＆ rspec 給 開發 及 測試環境
2. 新增欄位給 User, 更新 User model
3. 更新 router, 設定 letter opener 在 dev 環境內
4. rails g mailer 與設定 email 設定
5. 客製 inline css email 內容，i18n 雙語
6. 加入 smtp mailgun 的設定，加入env sample, 順便一起修正第三方登入的 typo
7.  修正一些 pull 下來的衝突 與 typo

展示如下：
[https://youtu.be/lRviFvYex-g](https://youtu.be/lRviFvYex-g)

