### PR TITLE
feat: 新增 忘記密碼 email 發送、重設密碼，客製化 email 頁面 (附 i18n 中/英文)

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -9,4 +9,12 @@ class UserMailer < Devise::Mailer
     opt[:reply_to] = "support@joband.co"
     super
   end
+
+  def reset_password_instructions(record, token, opt={})
+    headers["Custom-header"] = "Bar"
+    opt[:subject] = "密碼重設步驟"
+    opt[:from] = "noreply@joband.co"
+    opt[:reply_to] = "support@joband.co"
+    super
+  end
 end

--- a/app/views/user_mailer/reset_password_instructions.html.erb
+++ b/app/views/user_mailer/reset_password_instructions.html.erb
@@ -1,0 +1,46 @@
+<div style="background:#f9f9f9;padding:40px 0;margin:10px 0;border-bottom:1px solid #efefef">
+  <table style="border-spacing:0;border-collapse:collapse;width:100%;vertical-align:top;max-width:640px;margin:0 auto;padding:0;font-size:15px;font-family:Arial,Helvetica">
+    <tbody>
+      <tr>
+        <td>
+          <table style="border-spacing:0;border-collapse:collapse;width:100%;vertical-align:top;margin:20px 0;padding:0;font-size:14px">
+            <tbody>
+              <tr>
+                <td style="padding-bottom:16px">
+                  <span style="font-size:28px"><b>Hello, <%= @resource.email %></b></span>
+                </td>
+              </tr>
+              <tr>
+                <td style="padding-bottom:12px">
+                  <span style="font-size:14px"><%= t("email.reset_password_warning") %></span>
+                </td>
+              </tr>
+              <tr>
+                <td style="padding-bottom:16px;text-align:center">
+                  <%= link_to t("email.reset_my_password"), edit_password_url(@resource, reset_password_token: @token), class: "blink", style: "color:#fff;text-decoration:none;display:inline-block;color:#fff;border-radius:4px;border-bottom-width:2px;border-bottom-color:#ff6347;border-bottom-style:solid;background:#ff6347;padding:15px 40px;margin:10px auto;font-size:18px", target:"_blank" %>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <div style="text-align:center"></div>
+                </td>
+              </tr>
+              <tr>
+                <td style="padding-bottom:12px">
+                  <span style="font-size:14px"><%= t("email.reset_password_cancel") %></span>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <span style="font-size:14px;display:block">
+                    <br>Cheers,<br><%= t("email.by_joband") %>
+                  </span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -1,0 +1,30 @@
+<div class="bg-dark rounded-md px-10 py-5 flex-wrap w-60%">
+  <header class="block w-100% text-white">
+    <h2 class="h2"><%= t("user.change_your_password")%></h2>
+  </header>
+
+  <div class="block mx-auto w-100%">
+    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+      <%= render "users/shared/error_messages", resource: resource %>
+      <%= f.hidden_field :reset_password_token %>
+
+      <div class="field my-2">
+        <%= f.label :password, t("user.new_password"), class: "text-white" %><br />
+        <%= f.password_field :password, autofocus: true, autocomplete: "new-password", placeholder: t("user.min_password_placeholder") %>
+      </div>
+
+      <div class="field my-2">
+        <%= f.label :password_confirmation, t("user.confirm_new_password"), class: "text-white" %><br />
+        <%= f.password_field :password_confirmation, autocomplete: "new-password", placeholder: t("user.password_confirmation_placeholder") %>
+      </div>
+
+      <div class="actions">
+        <%= f.submit t("user.change_your_password"), class: "btn" %>
+      </div>
+    <% end %>
+  </div>
+
+  <div class="aside-info text-white">
+    <%= render "users/shared/links" %>
+  </div>
+</div>

--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -1,16 +1,23 @@
-<h2><%= t("user.forgot_password") %></h2>
+<div class="bg-dark rounded-md px-10 py-5 flex-wrap w-60%">
+  <header class="block w-100% text-white">
+    <h2 class="h2"><%= t("user.forgot_password") %></h2>
+  </header>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "users/shared/error_messages", resource: resource %>
+  <div class="block mx-auto w-100%">
+    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+      <%= render "users/shared/error_messages", resource: resource %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, placeholder: "email@example.com", autofocus: true, autocomplete: "email" %>
+      <div class="field my-2">
+        <%= f.label :email, class: "text-white" %><br />
+        <%= f.email_field :email, placeholder: "email@example.com", autofocus: true, autocomplete: "email" %>
+      </div>
+
+      <div class="actions">
+        <%= f.submit t("user.forgot_password_submit"), class: "btn" %>
+      </div>
+    <% end %>
   </div>
-
-  <div class="actions">
-    <%= f.submit t("user.forgot_password_submit") %>
+  <div class="aside-info text-white">
+    <%= render "users/shared/links" %>
   </div>
-<% end %>
-
-<%= render "users/shared/links" %>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,7 +2,7 @@ en:
   user:
     sign_up: "Sign Up"
     password: "Password"
-    min_password_placeholder: "8 characters minimum"
+    min_password_placeholder: "8 - 16 characters"
     password_confirmation: "Password confirmation"
     password_confirmation_placeholder: "Please confirmation your password again"
     not_receive_confirm: "Didn't receive confirmation email?"
@@ -12,9 +12,16 @@ en:
     remember_me: "Remember me"
     forgot_password: "Forgot your password?"
     forgot_password_submit: "Send mail to reset password"
+    change_your_password: "Change your password"
+    new_password: "New password"
+    confirm_new_password: "Confirm new password"
     not_yet: "Don’t have an account?"
     already: "Already a member?"
-
+  email:
+    by_joband: "JoBand Team"
+    reset_password_warning: "Someone has requested to change your password. You can do this through the link below."
+    reset_my_password: "Reset My Password"
+    reset_password_cancel: "If you didn't request this, please ignore and delete this email, your password won't be change."
   devise:
     confirmations:
       confirmed: "Your email address has been successfully confirmed."

--- a/config/locales/tw.yml
+++ b/config/locales/tw.yml
@@ -2,7 +2,7 @@ tw:
   user:
     sign_up: "加入 JoBand！"
     password: "密碼"
-    min_password_placeholder: "請輸入至少 8 字元"
+    min_password_placeholder: "請輸入 8 - 16 字元"
     password_confirmation: "確認密碼"
     password_confirmation_placeholder: "請再次確認密碼"
     not_receive_confirm: "沒有收到認證信嗎？"
@@ -12,9 +12,16 @@ tw:
     remember_me: "記住我"
     forgot_password: "忘記密碼？"
     forgot_password_submit: "發送重設密碼信件"
+    change_your_password: "更改您的密碼"
+    new_password: "新密碼"
+    confirm_new_password: "確認新密碼"
     not_yet: "還不是會員嗎？"
     already: "已經是會員了嗎？"
-    
+  email:
+    by_joband: "JoBand 開發團隊"
+    reset_password_warning: "有人向我們發出變更密碼的請求，您可以透過以下按鈕來變更密碼："
+    reset_my_password: "變更我的密碼"
+    reset_password_cancel: "如果不是您發出的變更請求，請忽略並刪除此信件，您的密碼將不會變更。"
   devise:
     confirmations:
       confirmed: "您的帳號已通過驗證，現在您已成功登入。"


### PR DESCRIPTION
如標題所示，共分兩次 小commit
發送 email 功能完成後，忘記密碼＋重設密碼，就只是多幾個頁面而已

1. 新增至 User_mailer
2. CSS 切版 忘記密碼 / 重設密碼，email內容畫面  (附 i18n 中/英文)

展示如下：
忘記密碼 View
<img width="1034" alt="截圖 2023-08-14 下午4 02 26" src="https://github.com/astrocamp/14th-JoBand/assets/128116961/b38a3455-0ae4-458f-b60d-dd1f0582b5e1">

email 信件 inline style
<img width="984" alt="截圖 2023-08-14 下午4 02 08" src="https://github.com/astrocamp/14th-JoBand/assets/128116961/edbcfc00-549c-4458-b585-b9f2251f791e">

更改密碼 View
<img width="1008" alt="截圖 2023-08-14 下午4 02 37" src="https://github.com/astrocamp/14th-JoBand/assets/128116961/ab6e5e1e-c39f-424d-a882-627f6cbe9138">

