### PR TITLE
feat: 加入 User model 跟 Profile 的關聯性

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 # or operating system, you probably want to add a global ignore instead:
 #   git config --global core.excludesfile '~/.gitignore_global'
 
+# Mac Store files
+.DS_Store
+
 # Ignore vscode setting
 /.vscode/.json
 
@@ -38,3 +41,4 @@
 
 #API KEY FILE
 .env
+.vscode/settings.json

--- a/Gemfile
+++ b/Gemfile
@@ -23,9 +23,9 @@ gem 'stimulus-rails'
 gem 'tailwindcss-rails'
 gem 'turbo-rails'
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
+gem 'pundit', '~> 2.3"
 
 group :development, :test do
-  # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[mri mingw x64_mingw]
   gem 'dotenv-rails'
   gem 'letter_opener', '~> 1.8'

--- a/Gemfile
+++ b/Gemfile
@@ -23,11 +23,11 @@ gem 'stimulus-rails'
 gem 'tailwindcss-rails'
 gem 'turbo-rails'
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
-gem 'pundit', '~> 2.3"
+gem "pundit", "~> 2.3"
+gem "dotenv-rails", "~> 2.8"
+
 
 group :development, :test do
-  gem 'debug', platforms: %i[mri mingw x64_mingw]
-  gem 'dotenv-rails'
   gem 'letter_opener', '~> 1.8'
   gem 'rspec-rails', '~> 6.0'
   gem 'rubocop', require: false
@@ -42,3 +42,5 @@ group :test do
   gem 'selenium-webdriver'
   gem 'webdrivers'
 end
+
+

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'sprockets-rails'
 
 gem 'bootsnap', require: false
 gem 'devise', '~> 4.9'
+gem 'dotenv-rails', '~> 2.8'
 gem 'image_processing', '~> 1.2'
 gem 'importmap-rails'
 gem 'jbuilder'
@@ -19,13 +20,11 @@ gem 'omniauth-google-oauth2'
 gem 'omniauth-rails_csrf_protection'
 gem 'pg', '~> 1.1'
 gem 'puma', '~> 5.0'
+gem 'pundit', '~> 2.3'
 gem 'stimulus-rails'
 gem 'tailwindcss-rails'
 gem 'turbo-rails'
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
-gem "pundit", "~> 2.3"
-gem "dotenv-rails", "~> 2.8"
-
 
 group :development, :test do
   gem 'letter_opener', '~> 1.8'
@@ -42,5 +41,3 @@ group :test do
   gem 'selenium-webdriver'
   gem 'webdrivers'
 end
-
-

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -196,6 +196,8 @@ GEM
     public_suffix (5.0.3)
     puma (5.6.6)
       nio4r (~> 2.0)
+    pundit (2.3.1)
+      activesupport (>= 3.0.0)
     racc (1.7.1)
     rack (2.2.8)
     rack-protection (3.1.0)
@@ -347,7 +349,9 @@ DEPENDENCIES
   omniauth-rails_csrf_protection
   pg (~> 1.1)
   puma (~> 5.0)
+  pundit (~> 2.3)
   rails (~> 7.0.6)
+  robocop (~> 0.1.1)
   rspec-rails (~> 6.0)
   rubocop
   selenium-webdriver

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,9 +87,6 @@ GEM
     concurrent-ruby (1.2.2)
     crass (1.0.6)
     date (3.3.3)
-    debug (1.8.0)
-      irb (>= 1.5.0)
-      reline (>= 0.3.1)
     devise (4.9.2)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -118,9 +115,6 @@ GEM
     importmap-rails (1.2.1)
       actionpack (>= 6.0.0)
       railties (>= 6.0.0)
-    io-console (0.6.0)
-    irb (1.7.4)
-      reline (>= 0.3.6)
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
@@ -235,8 +229,6 @@ GEM
     rainbow (3.1.1)
     rake (13.0.6)
     regexp_parser (2.8.1)
-    reline (0.3.7)
-      io-console (~> 0.5)
     responders (3.1.0)
       actionpack (>= 5.2)
       railties (>= 5.2)
@@ -336,9 +328,8 @@ PLATFORMS
 DEPENDENCIES
   bootsnap
   capybara
-  debug
   devise (~> 4.9)
-  dotenv-rails
+  dotenv-rails (~> 2.8)
   image_processing (~> 1.2)
   importmap-rails
   jbuilder
@@ -351,7 +342,6 @@ DEPENDENCIES
   puma (~> 5.0)
   pundit (~> 2.3)
   rails (~> 7.0.6)
-  robocop (~> 0.1.1)
   rspec-rails (~> 6.0)
   rubocop
   selenium-webdriver

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -13,51 +13,10 @@
   }
 }
 
-/* Font Style */
-.h1 {
-  @apply text-2xl block my-5;
-}
-
-.h2 {
-  @apply text-xl block my-5;
-}
-
-.h3 {
-  @apply text-lg block;
-}
-
-.h4 {
-  @apply text-base block;
-}
-
-/* session style */
-
-.logo-icon {
-  @apply cursor-pointer select-none text-xl;
-}
-
-.nav-link {
-  @apply cursor-pointer select-none hover:bg-nav-hov hover:duration-300 text-lg;
-}
-
-.aside-info {
-  @apply my-5;
-}
-
 /* link style */
 
 .blink {
   @apply underline cursor-pointer text-amber-500;
-}
-
-/* button style */
-
-.confirm-btn {
-  @apply cursor-pointer select-none rounded-lg bg-white text-black px-4 py-2 hover:bg-slate-100 hover:duration-300 my-5 ;
-}
-
-.cancel-btn {
-  @apply cursor-pointer select-none rounded-md
 }
 
 /*

--- a/app/controllers/Users/registrations_controller.rb
+++ b/app/controllers/Users/registrations_controller.rb
@@ -2,8 +2,8 @@
 
 module Users
   class RegistrationsController < Devise::RegistrationsController
-    # before_action :configure_sign_up_params, only: [:create]
-    # before_action :configure_account_update_params, only: [:update]
+    before_action :configure_sign_up_params, only: [:create]
+    before_action :configure_account_update_params, only: [:update]
 
     # GET /resource/sign_up
 
@@ -30,14 +30,14 @@ module Users
     # protected
 
     # If you have extra params to permit, append them to the sanitizer.
-    # def configure_sign_up_params
-    #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
-    # end
+    def configure_sign_up_params
+      devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
+    end
 
     # If you have extra params to permit, append them to the sanitizer.
-    # def configure_account_update_params
-    #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
-    # end
+    def configure_account_update_params
+      devise_parameter_sanitizer.permit(:account_update, keys: [:name])
+    end
 
     # The path used after sign up.
     # def after_sign_up_path_for(resource)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@
 
 class ApplicationController < ActionController::Base
   around_action :switch_locale
+  include Pundit::Authorization
   rescue_from ActiveRecord::RecordNotFound, with: :not_found
 
   def not_found

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -2,4 +2,8 @@
 
 class PagesController < ApplicationController
   def index; end
+
+  def set_profile
+    @profile = Profile.find(params[:id])
+  end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,10 +1,5 @@
 # frozen_string_literal: true
 
 class PagesController < ApplicationController
-  
   def index; end
-
-  def set_profile
-    @profile = Profile.find(params[:id])
-  end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class PagesController < ApplicationController
+  
   def index; end
 
   def set_profile

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -13,9 +13,9 @@ class ProfilesController < ApplicationController
   end
 
   def create
-    @profile = Profile.new(params_profile)
+    @profile = current_user.create_profile(params_profile)
     if @profile.save
-      redirect_to profiles_path, notice: '新增 profile 成功'
+      redirect_to profile_path(@profile), notice: '新增 profile 成功'
     else
       render :new
     end
@@ -29,7 +29,7 @@ class ProfilesController < ApplicationController
 
   def update
     if @profile.update(params_profile)
-      redirect_to profiles_path, notice: '新增 profile 成功'
+      redirect_to profiles_path(@profile), notice: '新增 profile 成功'
     else
       render :edit
     end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -2,9 +2,11 @@
 
 class ProfilesController < ApplicationController
   before_action :set_profile, only: %i[edit update show]
+  before_action :set_user, only: %i[show]
 
   def index
     @profiles = Profile.order(id: :desc)
+    @users = User.all
   end
 
   def new
@@ -43,5 +45,9 @@ class ProfilesController < ApplicationController
 
   def set_profile
     @profile = Profile.find(params[:id])
+  end
+
+  def set_user
+    @user = User.find(params[:id])
   end
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
+  default from: 'support@joband.co'
   layout 'mailer'
 end

--- a/app/models/band.rb
+++ b/app/models/band.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# frozen_string_literal: true
+
 class Band < ApplicationRecord
   # validates
   validates :name, presence: true

--- a/app/models/band.rb
+++ b/app/models/band.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-# frozen_string_literal: true
-
 class Band < ApplicationRecord
   # validates
   validates :name, presence: true

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -11,4 +11,5 @@ class Profile < ApplicationRecord
   has_one_attached :video
   has_many :profile_and_instrument
   has_many :instruments, through: :profile_and_instrument
+  belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,9 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable, :confirmable,
          :omniauthable, omniauth_providers: %i[facebook google_oauth2]
 
+  # associations
+  has_one :profile
+
   def self.find_for_google_oauth2(access_token, _signed_in_resource = nil)
     data = access_token.info
     user = User.where(google_token: access_token.credentials.token, google_uid: access_token.uid).first

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+class ApplicationPolicy
+  attr_reader :user, :record
+
+  def initialize(user, record)
+    @user = user
+    @record = record
+  end
+
+  def index?
+    false
+  end
+
+  def show?
+    false
+  end
+
+  def create?
+    false
+  end
+
+  def new?
+    create?
+  end
+
+  def update?
+    false
+  end
+
+  def edit?
+    update?
+  end
+
+  def destroy?
+    false
+  end
+
+  class Scope
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      raise NotImplementedError, "You must define #resolve in #{self.class}"
+    end
+
+    private
+
+    attr_reader :user, :scope
+  end
+end

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -1,1 +1,3 @@
-<h1>JoBand</h1>
+<div class="mx-auto w-fit">
+  <h1 class="text-2xl text-white py-5 px-5  ">Welcome to JoBand</h1>
+</div>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -1,3 +1,10 @@
-<div class="mx-auto w-fit">
-  <h1 class="text-2xl text-white py-5 px-5  ">Welcome to JoBand</h1>
+<div class="hero min-h-screen rounded-xl" style="background-image: url(https://static.wixstatic.com/media/89d386_ec4ca9be72c84dfba49634b689a0ef32~mv2.jpg/v1/fill/w_640,h_800,al_c,q_85,enc_auto/89d386_ec4ca9be72c84dfba49634b689a0ef32~mv2.jpg);">
+  <div class="hero-content text-center text-white">
+    <div class="max-w-md rounded-lg">
+      <h1 class="text-5xl font-bold">歡迎來到 JoBand </h1>
+      <p class="py-6">我們想邀請所有音樂家、樂手和音樂愛好者來到此處。無論您是一位樂手、一支樂團、音樂工作者，或者只是享受好音樂的友好人們。我們的期望能促進音樂社群更好的互動與交流，讓您能夠透過 JoBand 找到更多同好者。</p>
+      <button class="btn btn-warning">Get Started</button>
+      <p class="py-6">透過 JoBand，您可以輕鬆尋找合適的樂團成員。鼓手、吉他手、貝斯手，還是鍵盤手，我們的平台將幫助您找到完美的音樂拍檔。祝福您可以通過 JoBand 參與到您夢寐以求的音樂項目。</p>
+    </div>
+  </div>
 </div>

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -5,10 +5,6 @@
       <%= f.file_field :avatar, accept: "image/png, image/jpeg" %>
     </div>
     <div>
-      <%= f.label :name, "名稱" %>
-      <%= f.text_field :name %>
-    </div>
-    <div>
       <%= f.label :phone, "電話" %>
       <%= f.phone_field :phone, placeholder: '請輸入電話號碼' %>
     </div>

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -2,38 +2,30 @@
   <%= form_with( model: profile, data: { turbo: false } ) do |f| %>
     <div>
       <%= f.label :avatar, "上傳大頭照" %>
-      <%= f.file_field :avatar, accept: "image/png, image/jpeg" %>
+      <%= f.file_field :avatar, accept: "image/png, image/jpeg", class: "file-input file-input-sm file-input-warning w-full max-w-xs" %>
     </div>
     <div>
-      <%= f.label :phone, "電話" %>
-      <%= f.phone_field :phone, placeholder: '請輸入電話號碼' %>
+      <%= f.label :phone, "電話", class: "text-white" %><br />
+      <%= f.phone_field :phone, placeholder: '請輸入電話號碼', class: "input-md input-bordered w-full max-w-xs" %>
     </div>
     <div>
-      <%= f.label :location, "居住城市" %>
-      <%= f.text_field :location %>
+      <%= f.label :location, "居住城市", class: "text-white" %><br />
+      <%= f.text_field :location, placeholder: '請輸入居住城市', class: "input-md input-bordered w-full max-w-xs" %>
     </div>
     <div>
-      <%= f.label :seniority, "樂齡" %>
-      <%= f.number_field :seniority, min: 0 %>
+      <%= f.label :seniority, "樂齡", class: "text-white" %><br />
+      <%= f.number_field :seniority, min: 1, placeholder: '1年', class: "input-md input-bordered w-full max-w-xs" %>
     </div>
     <div>
-      <%= f.label :content, "簡介" %>
-      <%= f.text_area :content %>
+      <%= f.label :content, "簡介", class: "text-white" %><br />
+      <%= f.text_area :content, placeholder: '跟大家介紹一下自己。', class: "input-md input-bordered w-full max-w-xs" %>
     </div>
-    <p>使用樂器 instrument </p>
+    <p class="text-white">使用樂器 instrument </p>
     <div>
       <%= f.collection_check_boxes :instrument_ids, @instruments, :id, :name do |i| %>
         <%= i.label %>
         <%= i.check_box %>
       <% end %>
-    </div>
-    <div>
-      <%= f.label :music, "上傳音樂" %>
-      <%= f.file_field :music, accept: "audio/mpeg" %>
-    </div>
-    <div>
-      <%= f.label :video, "上傳影片" %>
-      <%= f.file_field :video, accept: "video/mp4" %>
     </div>
     <%= f.submit %>
   <% end %>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,5 +1,5 @@
 <div>
-  <h1>修改個人profile</h1>
+  <h2 class="text-4xl font-bold text-white my-5">編輯個人檔案</h2>
 </div>
 
 <%= render "form", profile: @profile %>

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -1,8 +1,16 @@
-<div class="flex flex-col w-full " >
+<div class="flex flex-col w-full" >
 
   <div class="flex flex-col items-center p-5 font-bold tracking-wide ">
     <h1 class="text-xl text-red-500 " >展示你的音樂作品集</h1>
-    <button class="p-2 my-4 text-base text-white rounded bg-slate-500 hover:bg-slate-600" ><%= link_to "新增 個人檔案", new_profile_path %></button>
+    <% if user_signed_in?%>
+      <% if current_user.profile.present? %>
+        
+      <% else %>
+        <button class="p-2 my-4 text-base text-white rounded bg-slate-500 hover:bg-slate-600" ><%= link_to "新增 個人檔案", new_profile_path %></button>
+      <% end %>
+    <% else %>
+      <button class="p-2 my-4 text-base text-white rounded bg-slate-500 hover:bg-slate-600" ><%= link_to "加入會員", new_user_registration_path %></button>
+    <% end %>
   </div>
 
   <div class="flex flex-wrap justify-center w-full " >

--- a/app/views/profiles/new.html.erb
+++ b/app/views/profiles/new.html.erb
@@ -1,5 +1,5 @@
 <div>
-  <h1>新增個人profile</h1>
+  <h2 class="text-4xl font-bold text-white my-5">新增個人檔案</h2>
 </div>
 
 <%= render "form", profile: @profile %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -3,7 +3,7 @@
     <div class="flex flex-col items-center my-3 ">
       <%= render "shared/avatar", model: @profile  %>
     </div>
-    <h1 class="my-3 mb-2 text-2xl font-bold text-black"><%= @profile.name %></h1>
+    <h1 class="my-3 mb-2 text-2xl font-bold text-black"><%= current_user.name %></h1>
     <p class="my-3 text-gray-700">電話號碼：<%= @profile.phone %></p>
     <p class="my-3 text-gray-700">居住城市：<%= @profile.location %></p>
     <p class="my-3 text-gray-700">樂齡：<%= @profile.seniority %></p>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -3,7 +3,7 @@
     <div class="flex flex-col items-center my-3 ">
       <%= render "shared/avatar", model: @profile  %>
     </div>
-    <h1 class="my-3 mb-2 text-2xl font-bold text-black"><%= current_user.name %></h1>
+    <h1 class="my-3 mb-2 text-2xl font-bold text-black"><%= @user.name %></h1>
     <p class="my-3 text-gray-700">電話號碼：<%= @profile.phone %></p>
     <p class="my-3 text-gray-700">居住城市：<%= @profile.location %></p>
     <p class="my-3 text-gray-700">樂齡：<%= @profile.seniority %></p>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -9,12 +9,14 @@
     <ul class="flex gap-5">
       <% if user_signed_in? %>
         <li>
-          <div class="dropdown dropdown-hover mb-32">
+          <div class="dropdown dropdown-hover dropdown-end mb-32">
             <label class="m-1 btn">
-              <%= link_to current_user.email, "#"%>
+              <%= link_to current_user.name, "#"%>
             </label>
             <ul class="p-2 shadow menu dropdown-content z-[1] bg-base-100 rounded-box w-52">
               <li><%= link_to "個人檔案", "#", class: "nav-link" %></li>
+              <li><%= link_to "我的樂團", "#", class: "nav-link" %></li>
+              <li><%= link_to "設定", "#", class: "nav-link" %></li>
               <li><%= link_to "登出", destroy_user_session_path,
                               data: { turbo_method: 'delete' }, class: "nav-link" %></li>
             </ul>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -9,14 +9,14 @@
     <ul class="flex gap-5">
       <% if user_signed_in? %>
         <li>
-          <div class="dropdown dropdown-hover dropdown-end mb-32">
+          <div class="dropdown dropdown-hover dropdown-end mb-1">
             <label class="m-1 btn">
               <%= link_to current_user.name, "#"%>
             </label>
             <ul class="p-2 shadow menu dropdown-content z-[1] bg-base-100 rounded-box w-52">
-              <li><%= link_to "個人檔案", "#", class: "nav-link" %></li>
+              <li><%= link_to "個人檔案", profile_path(current_user.profile), class: "nav-link" %></li>
               <li><%= link_to "我的樂團", "#", class: "nav-link" %></li>
-              <li><%= link_to "設定", "#", class: "nav-link" %></li>
+              <li><%= link_to "設定", edit_user_registration_path, class: "nav-link" %></li>
               <li><%= link_to "登出", destroy_user_session_path,
                               data: { turbo_method: 'delete' }, class: "nav-link" %></li>
             </ul>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -14,7 +14,11 @@
               <%= link_to current_user.name, "#"%>
             </label>
             <ul class="p-2 shadow menu dropdown-content z-[1] bg-base-100 rounded-box w-52">
-              <li><%= link_to "個人檔案", profile_path(current_user.profile), class: "nav-link" %></li>
+              <% if current_user.profile.present?%>
+                <li><%= link_to "個人檔案", profile_path(current_user.profile), class: "nav-link" %></li>
+              <% else %>
+                <li><%= link_to "個人檔案", new_profile_path, class: "nav-link" %></li>
+              <% end %>
               <li><%= link_to "我的樂團", "#", class: "nav-link" %></li>
               <li><%= link_to "設定", edit_user_registration_path, class: "nav-link" %></li>
               <li><%= link_to "登出", destroy_user_session_path,

--- a/app/views/user_mailer/confirmation_instructions.html.erb
+++ b/app/views/user_mailer/confirmation_instructions.html.erb
@@ -7,7 +7,7 @@
             <tbody>
               <tr>
                 <td style="padding-bottom:16px">
-                  <span style="font-size:28px"><b>歡迎加入 JoBand, <%= @email %>!</b></span>
+                  <span style="font-size:28px"><b>歡迎加入 JoBand, <%= @resource.name %>!</b></span>
                 </td>
               </tr>
               <tr>

--- a/app/views/user_mailer/reset_password_instructions.html.erb
+++ b/app/views/user_mailer/reset_password_instructions.html.erb
@@ -7,7 +7,7 @@
             <tbody>
               <tr>
                 <td style="padding-bottom:16px">
-                  <span style="font-size:28px"><b>Hello, <%= @resource.email %></b></span>
+                  <span style="font-size:28px"><b>Hello, <%= @resource.name %></b></span>
                 </td>
               </tr>
               <tr>

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -38,5 +38,3 @@
     <%= link_to "Back", :back, class: "btn btn-error rounded-md my-5 w-32" %>
   </div>
 <% end %>
-
-<%= link_to "Back", :back, class: "link mb-5 block" %>

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -1,0 +1,42 @@
+<h2 class="text-4xl font-bold text-white my-5"><%= t("user.settings") %></h2>
+  <div class="field mb-5">
+    <label class="text-white">Email Account</label><br />
+    <input type="text" placeholder="<%= @current_user.email %>" class="input input-bordered w-full max-w-xs" disabled />
+  </div>
+
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+  <%= render "users/shared/error_messages", resource: resource %>
+
+  <div class="field mb-5">
+    <%= f.label :name, t("user.display_name"),class: "text-white" %><br />
+    <%= f.text_field :name, autofocus: true, autocomplete: :off, class: "input-md input-bordered w-full max-w-xs" %>
+  </div>
+
+  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+  <% end %>
+
+  <div class="field mb-5">
+    <%= f.label :password, t("user.new_password"), class: "text-white" %> <br />
+    <%= f.password_field :password, placeholder: t("user.min_password_placeholder"),autocomplete: "new-password", class: "input-md input-bordered w-full max-w-xs" %>
+    <br /><i><%= t("user.leave_blank") %></i>
+  </div>
+
+  <div class="field mb-5">
+    <%= f.label :password_confirmation, t("user.password_confirmation"), class: "text-white" %><br />
+    <%= f.password_field :password_confirmation, placeholder: t("user.password_confirmation_placeholder"), autocomplete: "new-password", class: "input-md input-bordered w-full max-w-xs" %>
+  </div>
+
+  <div class="field mb-5">
+    <%= f.label :current_password, t("user.current_password"), class: "text-white" %><br />
+    <%= f.password_field :current_password, autocomplete: "current-password", class: "input-md input-bordered w-full max-w-xs" %>
+    <br /><i><%= t("user.need_current_password") %></i>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Update", class: "btn btn-success rounded-md my-5 w-32 mr-5" %>
+    <%= link_to "Back", :back, class: "btn btn-error rounded-md my-5 w-32" %>
+  </div>
+<% end %>
+
+<%= link_to "Back", :back, class: "link mb-5 block" %>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -1,35 +1,43 @@
-<div class="bg-dark rounded-md px-10 py-5 flex-wrap w-60%">
-  <header class="block w-100% text-white">
-    <h2 class="h2"><%= t("user.sign_up") %></h2>
-  </header>
+<div class="bg-dark rounded-md px-20 py-5 my-10 mx-auto flex justify-center w-2/4">
+  <div class="mx-auto">
+    <header class="flex text-white">
+      <h2 class="h2"><%= t("user.sign_up") %></h2>
+    </header>
 
-  <div class="block mx-auto w-100%">
-    <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-      <%= render "users/shared/error_messages", resource: resource %>
+    <div class="flex mx-auto">
+      <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+        <%= render "users/shared/error_messages", resource: resource %>
 
-      <div class="field my-2">
-        <%= f.label :email, class: "text-white" %><br />
-        <%= f.email_field :email, placeholder: "email@example.com", autofocus: true, autocomplete: "email" %>
-      </div>
+        <div class="field my-3">
+          <%= f.label :name, t("user.display_name"),class: "text-white" %><br />
+          <%= f.text_field :name, placeholder: "David Bowie", autofocus: true, autocomplete: :off, class: "input-md" %><br />
+          <em class="text-xs leading-3"><%= t("user.display_describe") %></em>  
+        </div>
 
-      <div class="field my-2">
-        <%= f.label :password, t("user.password"), class: "text-white" %>
-        <% if @minimum_password_length %>
-        <% end %><br />
-        <%= f.password_field :password, placeholder: t("user.min_password_placeholder") ,autocomplete: "new-password" %>
-      </div>
+        <div class="field my-3">
+          <%= f.label :email, class: "text-white" %><br />
+          <%= f.email_field :email, placeholder: "email@example.com", autofocus: true, autocomplete: "email", class: "input-md" %>
+        </div>
 
-      <div class="field my-2">
-        <%= f.label :password_confirmation, t("user.password_confirmation"), class: "text-white" %><br />
-        <%= f.password_field :password_confirmation, placeholder: t("user.password_confirmation_placeholder"), autocomplete: "new-password" %>
-      </div>
+        <div class="field my-3">
+          <%= f.label :password, t("user.password"), class: "text-white" %>
+          <% if @minimum_password_length %>
+          <% end %><br />
+          <%= f.password_field :password, placeholder: t("user.min_password_placeholder") ,autocomplete: "new-password", class: "input-md" %>
+        </div>
 
-      <div class="actions">
-        <%= f.submit t("user.sign_up"), class: "btn" %>
-      </div>
-    <% end %>
-  </div>
-  <div class="aside-info text-white">
-    <%= render "users/shared/links" %>
+        <div class="field my-3">
+          <%= f.label :password_confirmation, t("user.password_confirmation"), class: "text-white" %><br />
+          <%= f.password_field :password_confirmation, placeholder: t("user.password_confirmation_placeholder"), autocomplete: "new-password", class: "input-md" %>
+        </div>
+
+        <div class="actions">
+          <%= f.submit t("user.sign_up"), class: "btn btn-block" %>
+        </div>
+      <% end %>
+    </div>
+    <div class="my-5 text-white">
+      <%= render "users/shared/links" %>
+    </div>
   </div>
 </div>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,33 +1,37 @@
-<div class="bg-dark rounded-md px-10 py-5 flex-wrap w-60%">
-  <header class="block w-100% text-white">
-    <h2 class="h2"><%= t("user.login") %></h2>
-  </header>
+<div class="bg-dark rounded-md px-20 py-5 my-10 mx-auto flex justify-center w-2/4">
+  <div class="mx-auto">
+    <header class="flex text-white">
+      <h2 class="h2"><%= t("user.login") %></h2>
+    </header>
 
-<div class="block mx-auto w-100%">
-  <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-    <div class="field">
-      <%= f.label :email, class: "text-white" %><br />
-      <%= f.email_field :email, placeholder: "email@example.com", autofocus: true, autocomplete: "email" %>
-    </div>
+    <div class="flex mx-auto">
+    <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+      <div class="field my-3">
+        <%= f.label :email, class: "text-white" %><br />
+        <%= f.email_field :email, placeholder: "email@example.com", autofocus: true, autocomplete: "email", class: "input-md" %>
+      </div>
 
-    <div class="field my-2">
-      <%= f.label :password, t("user.password"), class: "text-white" %><br />
-      <%= f.password_field :password, placeholder: t("user.password"),autocomplete: "current-password" %>
-    </div>
+      <div class="field my-3">
+        <%= f.label :password, t("user.password"), class: "text-white" %><br />
+        <%= f.password_field :password, placeholder: t("user.password"),autocomplete: "current-password", class: "input-md" %>
+      </div>
 
-    <% if devise_mapping.rememberable? %>
-      <div class="field my-2">
-        <%= f.check_box :remember_me %>
-        <%= f.label :remember_me, t("user.remember_me"), class: "text-white" %>
+      <% if devise_mapping.rememberable? %>
+        <div class="field my-3">
+          <label class="cursor-pointer label">
+            <%= f.check_box :remember_me, checked: "checked", class: "checkbox checkbox-success mr-1" %>
+            <span class="mr-auto"><%= t("user.remember_me") %></span>
+          </label>
+        </div>
+      <% end %>
+
+      <div class="actions">
+        <%= f.submit t("user.login"), class: "btn btn-block" %>
       </div>
     <% end %>
-
-    <div class="actions">
-      <%= f.submit t("user.login"), class: "btn" %>
     </div>
-  <% end %>
-</div>
-  <div class="aside-info text-white">
-    <%= render "users/shared/links" %>
+    <div class="my-5 text-white">
+      <%= render "users/shared/links" %>
+    </div>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -19,6 +19,11 @@ en:
     confirm_new_password: "Confirm new password"
     not_yet: "Don’t have an account?"
     already: "Already a member?"
+    settings: "Settings"
+    new_password: "New Password"
+    current_password: "Current Password"
+    need_current_password: "(we need your current password to confirm your changes)"
+    leave_blank: "(leave blank if you don't want to change it)"
   email:
     by_joband: "JoBand Team"
     reset_password_warning: "Someone has requested to change your password. You can do this through the link below."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,6 +1,8 @@
 en:
   user:
     sign_up: "Sign Up"
+    display_name: "Display Name"
+    display_describe: "Enter your display name. You can change it later"
     password: "Password"
     min_password_placeholder: "8 - 16 characters"
     password_confirmation: "Password confirmation"

--- a/config/locales/tw.yml
+++ b/config/locales/tw.yml
@@ -1,6 +1,8 @@
 tw:
   user:
     sign_up: "加入 JoBand！"
+    display_name: "暱稱"
+    display_describe: "輸入的暱稱之後還可以進行變更"
     password: "密碼"
     min_password_placeholder: "請輸入 8 - 16 字元"
     password_confirmation: "確認密碼"

--- a/config/locales/tw.yml
+++ b/config/locales/tw.yml
@@ -19,6 +19,11 @@ tw:
     confirm_new_password: "確認新密碼"
     not_yet: "還不是會員嗎？"
     already: "已經是會員了嗎？"
+    settings: "設定"
+    new_password: "新密碼"
+    current_password: "目前密碼"
+    need_current_password: "(我們需要您目前的密碼來確認您的變更。)"
+    leave_blank: "（留白如果您不打算更換密碼）"
   email:
     by_joband: "JoBand 開發團隊"
     reset_password_warning: "有人向我們發出變更密碼的請求，您可以透過以下按鈕來變更密碼："

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,9 +2,9 @@
 
 Rails.application.routes.draw do
   root 'pages#index'
-  
+
   resources :pages, only: [:index]
-  
+
   devise_for :users, controllers: {
     sessions: 'users/sessions',
     registrations: 'users/registrations',
@@ -13,5 +13,5 @@ Rails.application.routes.draw do
     confirmations: 'users/confirmations'
   }
   resources :profiles, except: [:destroy]
-  resources :bands , except: [:destroy]
+  resources :bands, except: [:destroy]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  root 'pages#index'
+  
+  resources :pages, only: [:index]
+  
   devise_for :users, controllers: {
     sessions: 'users/sessions',
     registrations: 'users/registrations',
@@ -8,12 +12,6 @@ Rails.application.routes.draw do
     omniauth_callbacks: 'users/omniauth_callbacks',
     confirmations: 'users/confirmations'
   }
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
   resources :profiles, except: [:destroy]
-  # Defines the root path route ("/")
-  root 'pages#index'
-
-  resources :pages, only: [:index]
-
-  resources :bands, except: [:destroy]
+  resources :bands , except: [:destroy]
 end

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -10,6 +10,7 @@ module.exports = {
   
   theme: {
     fontSize: {
+      xs: ['12px', '14px'],
       sm: ['14px', '20px'],
       base: ['16px', '24px'],
       lg: ['20px', '28px'],

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -9,23 +9,11 @@ module.exports = {
   ],
   
   theme: {
-    fontSize: {
-      xs: ['12px', '14px'],
-      sm: ['14px', '20px'],
-      base: ['16px', '24px'],
-      lg: ['20px', '28px'],
-      xl: ['24px', '32px'],
-      '2xl': ['30px', '36px'],
-    },
     extend: {
-      // fontFamily: {
-      //   sans: ['Inter var', ...defaultTheme.fontFamily.sans],
-      // },
       colors: {
         'dark': '#444',
         'nav-hov': '#2f3136',
       },
-      
     },
   },
   // plugins: [

--- a/db/migrate/20230817094350_add_user_relation_with.rb
+++ b/db/migrate/20230817094350_add_user_relation_with.rb
@@ -1,0 +1,5 @@
+class AddUserRelationWith < ActiveRecord::Migration[7.0]
+  def change
+    add_belongs_to :profiles, :user, index: true
+  end
+end

--- a/db/migrate/20230817094350_add_user_relation_with.rb
+++ b/db/migrate/20230817094350_add_user_relation_with.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddUserRelationWith < ActiveRecord::Migration[7.0]
   def change
     add_belongs_to :profiles, :user, index: true

--- a/db/migrate/20230817120153_add_user_name_to_null_false.rb
+++ b/db/migrate/20230817120153_add_user_name_to_null_false.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 class AddUserNameToNullFalse < ActiveRecord::Migration[7.0]
   def up
     change_column_null(:users, :name, false)
   end
-  
+
   def down
     change_column_null(:users, :name, true)
   end

--- a/db/migrate/20230817120153_add_user_name_to_null_false.rb
+++ b/db/migrate/20230817120153_add_user_name_to_null_false.rb
@@ -1,0 +1,9 @@
+class AddUserNameToNullFalse < ActiveRecord::Migration[7.0]
+  def up
+    change_column_null(:users, :name, false)
+  end
+  
+  def down
+    change_column_null(:users, :name, true)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 20_230_816_040_921) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_17_120153) do
   # These are extensions that must be enabled in order to support this database
   enable_extension 'plpgsql'
   create_table 'action_text_rich_texts', force: :cascade do |t|
@@ -86,14 +86,16 @@ ActiveRecord::Schema[7.0].define(version: 20_230_816_040_921) do
     t.index ['profile_id'], name: 'index_profile_and_instruments_on_profile_id'
   end
 
-  create_table 'profiles', force: :cascade do |t|
-    t.string 'name'
-    t.integer 'phone'
-    t.string 'location'
-    t.integer 'seniority'
-    t.text 'content'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
+  create_table "profiles", force: :cascade do |t|
+    t.string "name"
+    t.integer "phone"
+    t.string "location"
+    t.integer "seniority"
+    t.text "content"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id"
+    t.index ["user_id"], name: "index_profiles_on_user_id"
   end
 
   create_table 'styles', force: :cascade do |t|
@@ -103,7 +105,7 @@ ActiveRecord::Schema[7.0].define(version: 20_230_816_040_921) do
   end
 
   create_table 'users', force: :cascade do |t|
-    t.string 'name'
+    t.string 'name', null: false
     t.string 'email', default: '', null: false
     t.string 'encrypted_password', default: '', null: false
     t.string 'reset_password_token'

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -10,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_17_120153) do
+ActiveRecord::Schema[7.0].define(version: 20_230_817_120_153) do
   # These are extensions that must be enabled in order to support this database
   enable_extension 'plpgsql'
   create_table 'action_text_rich_texts', force: :cascade do |t|
@@ -86,16 +88,16 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_17_120153) do
     t.index ['profile_id'], name: 'index_profile_and_instruments_on_profile_id'
   end
 
-  create_table "profiles", force: :cascade do |t|
-    t.string "name"
-    t.integer "phone"
-    t.string "location"
-    t.integer "seniority"
-    t.text "content"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.bigint "user_id"
-    t.index ["user_id"], name: "index_profiles_on_user_id"
+  create_table 'profiles', force: :cascade do |t|
+    t.string 'name'
+    t.integer 'phone'
+    t.string 'location'
+    t.integer 'seniority'
+    t.text 'content'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.bigint 'user_id'
+    t.index ['user_id'], name: 'index_profiles_on_user_id'
   end
 
   create_table 'styles', force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # This file should contain all the record creation needed to seed the database with its default values.
 # The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
 #

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 # This file should contain all the record creation needed to seed the database with its default values.
 # The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
 #


### PR DESCRIPTION
加入 User model 跟 Profile 的關聯性

User has_one Profile
Profile belongs_to User

抱歉，更新一下應該是共計 16 個小 commit
但前面8個是 pundit 的研究 跟 歸位 ＋ rubocop 的廢物小檔案

以下則是後面8個真正有功能的 commit 的說明

> **先說尚未解決的問題：**
> 
> - Profile index 還無法正確顯示 User name，但至少不會壞可以進去
> - Profile index 原本有一顆新增個人資料的按鈕（雖然不應該在那），暫時改為：
>   - - 未登入時，會顯示 加入會員的按鈕
>   - - 登入沒有建立profile的用戶時，會顯示 建立個人資料 的按鈕
>   - - 登入已經有個人資料的用戶時，則不會顯示任何按鈕
> - 尚未完成 註冊email 後 的下一個 頁面，會放在下一Part 進行
<img width="400" alt="截圖 2023-08-18 下午5 13 55" src="https://github.com/astrocamp/14th-JoBand/assets/128116961/d6daf33e-d148-4e02-8a2a-e90511194b9e">


1. 增加欄位 `add_belongs_to :profiles, :user, index: true`，攥寫 user.rb & profile.rb

2. 重構 page 以及 profile 的 controllers，調整 profile 幾個 view，以顯示正確資料
注意： 與助教討論後，留下User 的 name 欄位作為暱稱(並改為必填），Profiles 的 name 暫時沒有顯示（欄位未刪除）
<img width="400" alt="截圖 2023-08-18 下午5 05 24" src="https://github.com/astrocamp/14th-JoBand/assets/128116961/c626e37b-1b8e-4a2a-9517-20a35191e2c3">

3. 因為原本首頁太空，看不順眼，先建構了一個暫時首頁。
<img width="400" alt="截圖 2023-08-18 下午5 04 51" src="https://github.com/astrocamp/14th-JoBand/assets/128116961/134a07b8-a001-43bf-bddf-284472ed49e8">

4. 啟用用戶設定功能，加入可以更改 User 暱稱 以及 User 密碼的功能 （Email 不給改)
5. 移除部分錯亂的CSS語法，並將setting 加入 i18n 中/英語
<img width="400" alt="截圖 2023-08-18 下午5 03 05" src="https://github.com/astrocamp/14th-JoBand/assets/128116961/ba64a0a7-8aaa-494e-b498-6a6cb4fb8101">

6. 加入正確 navbar 使 個人檔案 顯示正確的個人資料，且用戶沒有建立資料時，會暫時先導入新建個人資料頁面
<img width="254" alt="截圖 2023-08-18 下午4 49 21" src="https://github.com/astrocamp/14th-JoBand/assets/128116961/b47fbfaa-fd38-4493-80d1-22855d183249">

7. 加入ＣＳＳ給 Profile 表單頁面
<img width="400" alt="截圖 2023-08-18 下午5 06 11" src="https://github.com/astrocamp/14th-JoBand/assets/128116961/92bf4679-3d6a-4af2-9590-7649c09772dc">

<img width="400" alt="截圖 2023-08-18 下午5 07 12" src="https://github.com/astrocamp/14th-JoBand/assets/128116961/ded099ec-c15f-49a6-b202-66795705d18f">

8. 刪除setting 裡，最底下一個重複的連結按鈕







