### PR TITLE
fix: 修復先前的誤刪，加回 音樂 跟 影片欄位

### DIFF
--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -27,6 +27,14 @@
         <%= i.check_box %>
       <% end %>
     </div>
+    <div>
+      <%= f.label :music, "上傳音樂" %>
+      <%= f.file_field :music, accept: "audio/mpeg" %>
+    </div>
+    <div>
+      <%= f.label :video, "上傳影片" %>
+      <%= f.file_field :video, accept: "video/mp4" %>
+    </div>
     <%= f.submit %>
   <% end %>
 </div>


### PR DESCRIPTION
修復先前的誤刪，加回 音樂 跟 影片欄位

原位置在：
views/profiles/_form.html.erb
＃34~41行

<img width="1269" alt="截圖 2023-08-21 下午2 39 29" src="https://github.com/astrocamp/14th-JoBand/assets/128116961/d1493696-65b6-453f-af82-c8b64d94ed6d">
