### PR TITLE
fix: 更新 Nav 的 Band 路徑，修正 Profile show 的名字顯示錯誤

### DIFF
--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -3,7 +3,7 @@
     <div class="flex flex-col items-center my-3 h-[200px] w-[200px] relative ">
       <%= render "shared/avatar", model: @profile  %>
     </div>
-    <h1 class="my-3 mb-2 text-2xl font-bold text-black"><%= @user.name %></h1>
+    <h1 class="my-3 mb-2 text-2xl font-bold text-black"><%= @profile.user.name %></h1>
     <p class="my-3 text-gray-700">電話號碼：<%= @profile.phone %></p>
     <p class="my-3 text-gray-700">居住城市：<%= @profile.location %></p>
     <p class="my-3 text-gray-700">樂齡：<%= @profile.seniority %></p>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -15,11 +15,11 @@
             </label>
             <ul class="p-2 shadow menu dropdown-content z-[1] bg-base-100 rounded-box w-52">
               <% if current_user.profile.present?%>
-                <li><%= link_to "個人檔案", profile_path(current_user), class: "nav-link" %></li>
+                <li><%= link_to "個人檔案", profile_path(current_user.profile.id), class: "nav-link" %></li>
+                <li><%= link_to "我的樂團", new_band_path, class: "nav-link" %></li>
               <% else %>
                 <li><%= link_to "個人檔案", new_profile_path, class: "nav-link" %></li>
               <% end %>
-              <li><%= link_to "我的樂團", "#", class: "nav-link" %></li>
               <li><%= link_to "設定", edit_user_registration_path, class: "nav-link" %></li>
               <li><%= link_to "登出", destroy_user_session_path,
                               data: { turbo_method: 'delete' }, class: "nav-link" %></li>


### PR DESCRIPTION
修正 "個人資料“ 名字顯示錯誤的問題，顯示正確的 User name
<img width="300" alt="截圖 2023-08-22 下午4 49 41" src="https://github.com/astrocamp/14th-JoBand/assets/128116961/83f24531-21ba-410e-8dfe-8161b0bdc6f7">

更新 Nav 關於 “我的樂團” 的路徑
如果 使用者未建立 Profile 是無法創建樂團的 （目前僅視覺上不顯示按鈕，更多判斷等待 User 與 Band 關聯性完成，待捕上）

<img width="248" alt="截圖 2023-08-22 下午4 46 30" src="https://github.com/astrocamp/14th-JoBand/assets/128116961/1666235c-17d0-4fa6-bfdb-6eb1b5624036">


<img width="253" alt="截圖 2023-08-22 下午4 46 59" src="https://github.com/astrocamp/14th-JoBand/assets/128116961/4e602411-14c0-47fd-91af-5b21aa5278a3">

