### PR TITLE
調整 Profile show css 

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -85,7 +85,7 @@
 }
 
 .joband-shadow{
-  @apply drop-shadow-2xl
+  @apply drop-shadow-xl
 }
 
 .joband-line-bk{

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -80,7 +80,7 @@
   @apply bg-[#EE9545] rounded-full px-4 py-2 text-white cursor-pointer select-none hover:bg-[#e9ab75] hover:duration-300
 }
 
-.joband-bk{
+.joband-text-bk{
   @apply text-[#2A323A]
 }
 

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -16,7 +16,7 @@ class Profile < ApplicationRecord
 
   def default_instrument(profile)
     if profile.instruments != []
-      instruments.first.name
+      instruments.first
     else
       'listener'
     end

--- a/app/views/profiles/_band.html.erb
+++ b/app/views/profiles/_band.html.erb
@@ -1,14 +1,16 @@
 <% if @profile.user.bands.any? %>
   <% @profile.user.bands.each do |band| %>
     <%= link_to band_path(band), action: 'go' do %>
-    <div class="mx-2">
-      <%= band.name %>
-      <div class="w-20 h-20 relative">
+    <div class="flex justify-center flex-wrap mx-2 w-[180px]">
+      <div class="relative w-[120px] h-[120px] mt-5">
         <%= render 'shared/avatar' , model: band %>
+      </div>
+      <div class="text-center h2 joband-text-bk joband-shadow">
+        <%= band.name %>
       </div>
     </div>
     <% end %>
   <% end %>
 <% else %>
-  <p>未加入樂團</p>
+  <p class="w-full my-3 text-gray-400 h4">未加入樂團</p>
 <% end %>

--- a/app/views/profiles/_profile.html.erb
+++ b/app/views/profiles/_profile.html.erb
@@ -4,8 +4,8 @@
   </div>
 
   <div class="w-[450px] flex flex-wrap p-5">
-    <p class=" w-full font-semibold text-[#2A323A] h2 drop-shadow-md"><%= profile.user.name %></p>
-    <p class=" w-full block h-[70px] text-gray-700"><%= profile.content.truncate(100) %></p>
+    <p class="w-full font-semibold joband-text-bk h2 drop-shadow-md"><%= profile.user.name %></p>
+    <p class=" w-full block h-[70px] joband-text-bk"><%= profile.content.truncate(100) %></p>
     <div class="flex w-full mt-4">
       <% if profile.location.present? %>
         <a href="#" class=" z-[1] mr-5 shadow-md joband-tag-location"><%= profile.location %></a>
@@ -16,67 +16,8 @@
     </div>
   </div>
 
-  <div class="w-[200px] h-[200px] flex justify-center items-center">
-  
-      <% if profile.default_instrument(profile) == "Vocal" %>
-        <div class="flex flex-wrap justify-center w-[150px] relative">
-          <a href="#" class="flex items-center justify-center z-[1]">
-            <img src="/icon_img/vocal.svg" alt="vocal_icon" class="absolute w-1/2 p-1 drop-shadow">
-            <div class="block w-[120px] h-[120px] bg-white rounded-full shadow-inner"></div>
-          </a>
-          <p class="block mt-2 font-semibold text-[#2A323A]">VOCAL</p>
-        </div>
-      <% end %>
-      
-      <% if profile.default_instrument(profile) == "Guitar" %>
-        <div class="flex flex-wrap justify-center w-[150px] relative">
-          <a href="#" class="flex items-center justify-center z-[1]">
-            <img src="/icon_img/guitar.svg" alt="guitar_icon" class="absolute w-1/2 p-1 drop-shadow">
-            <div class="block w-[120px] h-[120px] bg-white rounded-full shadow-inner"></div>
-          </a>
-          <p class="block mt-2 font-semibold text-[#2A323A]">GUITAR</p>
-        </div>
-      <% end %>
-
-      <% if profile.default_instrument(profile) == "Drum" %>
-        <div class="flex flex-wrap justify-center w-[150px] relative">
-          <a href="#" class="flex items-center justify-center z-[1]">
-            <img src="/icon_img/drum.svg" alt="drum_icon" class="absolute w-1/2 p-1 drop-shadow">
-            <div class="block w-[120px] h-[120px] bg-white rounded-full shadow-inner"></div>
-          </a>
-          <p class="block mt-2 font-semibold text-[#2A323A]">DRUM</p>
-        </div>
-      <% end %>
-
-      <% if profile.default_instrument(profile) == "Bass" %>
-        <div class="flex flex-wrap justify-center w-[150px] relative">
-          <a href="#" class="flex items-center justify-center z-[1]">
-            <img src="/icon_img/bass.svg" alt="bass_icon" class="absolute w-1/2 p-1 drop-shadow">
-            <div class="block w-[120px] h-[120px] bg-white rounded-full shadow-inner"></div>
-          </a>
-          <p class="block mt-2 font-semibold text-[#2A323A]">BASS</p>
-        </div>
-      <% end %>
-
-      <% if profile.default_instrument(profile) == "Keyboard" %>
-        <div class="flex flex-wrap justify-center w-[150px] relative">
-          <a href="#" class="flex items-center justify-center z-[1]">
-            <img src="/icon_img/keyboard.svg" alt="keyboard_icon" class="absolute w-1/2 p-1 drop-shadow">
-            <div class="block w-[120px] h-[120px] bg-white rounded-full shadow-inner"></div>
-          </a>
-          <p class="block mt-2 font-semibold text-[#2A323A]">KEYBOARD</p>
-        </div>
-      <% end %>
-      
-      <% if profile.default_instrument(profile) == "listener" %>
-        <div class="flex flex-wrap justify-center w-[150px] relative">
-          <a href="#" class="flex items-center justify-center z-[1]">
-            <img src="/icon_img/listener.svg" alt="listener_icon" class="absolute w-1/2 p-1 drop-shadow">
-            <div class="block w-[120px] h-[120px] bg-white rounded-full shadow-inner"></div>
-          </a>
-          <p class="block mt-2 font-semibold text-[#2A323A]">LISTENER</p>
-        </div>
-      <% end %>
+  <div class="w-[150px] h-[150px] flex justify-center items-center">
+    <%= render "/shared/instrument", instrument: profile.default_instrument(profile) %>
   </div>
   <%= link_to '', profile_path(profile), class: "block w-full h-full absolute" %>
 </div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,41 +1,47 @@
-<div class="flex justify-center w-11/12 h-auto p-6 mx-auto rounded-lg shadow-md bg-slate-100">  
-  <div class="flex flex-col items-center w-full p-2 ">
-
-    <div class="flex flex-col items-center my-3 h-[200px] w-[200px] relative ">
-      <%= render "shared/avatar", model: @profile  %>
-    </div>
+<div class="flex flex-wrap justify-center w-11/12 h-auto mx-auto p-10 rounded-[50px] shadow-md bg-slate-100">  
+  <div class="my-10 h-[200px] w-[200px] relative ">
+    <%= render "shared/avatar", model: @profile  %>
+  </div>
+  <h1 class="w-full mb-10 text-2xl font-bold text-center joband-shadow joband-text-bk"><%= @user.name %></h1>
     
-    <%= link_to '創建樂團', new_band_path, class:'btn btn-sm' %>
-    <h1 class="my-3 mb-2 text-2xl font-bold text-black"><%= @user.name %></h1>
-    <p class="my-3 text-gray-700">電話號碼：<%= @profile.phone %></p>
-    <p class="my-3 text-gray-700">居住城市：<%= @profile.location %></p>
-    <p class="my-3 text-gray-700">樂齡：<%= @profile.seniority %></p>
-    <p class="text-gray-700">內容：<%= @profile.content %></p>
-    <p>所屬樂團</p>
-    <div class="center">
-      <%= render 'band' %>
-    </div>
-      
-    <div class="flex flex-col items-center my-3 ">
-      <% if @profile.music.attached? %>
-        <audio controls controlsList="nodownload">
-          <source src="<%= url_for(@profile.music) %>" type="audio/mpeg">
-          您的瀏覽器不支援音樂格式
-        </audio>
-      <% else %>
-        <p>沒有上傳任何音樂檔案</p>
+  <div class="flex flex-wrap justify-center w-full px-40 joband-text-bk">
+    <div class="flex justify-around w-auto mb-12">
+      <% @profile.instruments.each do |instrument| %>
+        <div class="w-[80px] h-[80px] flex relative mx-3 my-3">
+          <%= render "/shared/instrument", instrument: instrument %>
+        </div>
       <% end %>
     </div>
-
-    <div class="flex flex-col items-center my-3 ">
-      <% if @profile.video.attached? %>
-        <video width="640" height="360" controls controlsList="nodownload">
-          <source src="<%= url_for(@profile.video) %>" type="video/mp4">
-          您的瀏覽器不支援影片格式
-        </video>
-      <% else %>
-        <p>沒有上傳任何影片檔案</p>
-      <% end %>
+    <span class="w-full joband-line-bk"></span>
+    <p class="w-full h3">電話號碼：<%= @profile.phone %></p>
+    <span class="w-full joband-line-bk"></span>
+    <p class="w-full h3">居住城市：<%= @profile.location %></p>
+    <span class="w-full joband-line-bk"></span>
+    <p class="w-full h3">樂齡：<%= @profile.seniority %></p>
+    <span class="w-full joband-line-bk"></span>
+    <p class="w-full h3">內容：<%= @profile.content %></p>
+    <span class="w-full joband-line-bk"></span>
+    <div class="flex flex-col w-full my-5">
+      <div class="my-3 ">
+        <% if @profile.music.attached? %>
+          <audio controls controlsList="nodownload" class="w-full">
+            <source src="<%= url_for(@profile.music) %>" type="audio/mpeg">
+            您的瀏覽器不支援音樂格式
+          </audio>
+        <% else %>
+          <p class="w-full">沒有上傳任何音樂檔案</p>
+        <% end %>
+      </div>
+      <div class="my-3 ">
+        <% if @profile.video.attached? %>
+          <video width="640" height="360" controls controlsList="nodownload" class="w-full">
+            <source src="<%= url_for(@profile.video) %>" type="video/mp4">
+            您的瀏覽器不支援影片格式
+          </video>
+        <% else %>
+          <p class="w-full">沒有上傳任何影片檔案</p>
+        <% end %>
+      </div>
     </div>
     <%= link_to '資料更新', edit_profile_path, class:'btn btn-sm' %>
 

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -2,12 +2,14 @@
   <div class="my-10 h-[200px] w-[200px] relative ">
     <%= render "shared/avatar", model: @profile  %>
   </div>
-  <h1 class="w-full mb-10 text-2xl font-bold text-center joband-shadow joband-text-bk"><%= @user.name %></h1>
-    
-  <div class="flex flex-wrap justify-center w-full px-40 joband-text-bk">
+  <h1 class="w-full mb-5 text-2xl font-bold text-center joband-shadow joband-text-bk"><%= @user.name %></h1>
+  <% if current_user&.id == @profile.id %>
+    <%= link_to '創建樂團', new_band_path, class:'joband-action-btn' %>
+  <% end %>
+  <div class="flex flex-wrap justify-center w-full px-40 mt-5 joband-text-bk">
     <div class="flex justify-around w-auto mb-12">
       <% @profile.instruments.each do |instrument| %>
-        <div class="w-[80px] h-[80px] flex relative mx-3 my-3">
+        <div class="w-[100px] h-[100px] flex relative mx-3 my-3">
           <%= render "/shared/instrument", instrument: instrument %>
         </div>
       <% end %>
@@ -21,6 +23,11 @@
     <span class="w-full joband-line-bk"></span>
     <p class="w-full h3">內容：<%= @profile.content %></p>
     <span class="w-full joband-line-bk"></span>
+    <p class="w-full h3">所屬樂團：</p>
+    <div class="flex flex-wrap w-full my-5 ">
+      <%= render 'band' %>
+    </div>
+    <span class="w-full joband-line-bk"></span>
     <div class="flex flex-col w-full my-5">
       <div class="my-3 ">
         <% if @profile.music.attached? %>
@@ -29,7 +36,7 @@
             您的瀏覽器不支援音樂格式
           </audio>
         <% else %>
-          <p class="w-full">沒有上傳任何音樂檔案</p>
+          <p class="w-full text-gray-400 h4">沒有上傳任何音樂檔案</p>
         <% end %>
       </div>
       <div class="my-3 ">
@@ -39,12 +46,13 @@
             您的瀏覽器不支援影片格式
           </video>
         <% else %>
-          <p class="w-full">沒有上傳任何影片檔案</p>
+          <p class="w-full text-gray-400 h4">沒有上傳任何影片檔案</p>
         <% end %>
       </div>
     </div>
-    <%= link_to '資料更新', edit_profile_path, class:'btn btn-sm' %>
-
+    <% if current_user&.id == @profile.id %>
+      <%= link_to '資料更新', edit_profile_path, class:'joband-action-btn' %>
+    <% end %>
   </div>  
 </div>
 

--- a/app/views/shared/_instrument.html.erb
+++ b/app/views/shared/_instrument.html.erb
@@ -1,0 +1,59 @@
+<% if instrument.name == "Vocal" %>
+  <div class="relative flex flex-wrap justify-center w-h-full">
+    <a href="#" class="flex h-full w-full items-center justify-center z-[1]">
+      <img src="/icon_img/vocal.svg" alt="vocal_icon" class="absolute w-1/2 p-1 drop-shadow">
+      <div class="bg-white rounded-full shadow-inner w-h-full"></div>
+    </a>
+    <p class="block mt-2 font-semibold joband-text-bk">VOCAL</p>
+  </div>
+<% end %>
+
+<% if instrument.name == "Guitar" %>
+  <div class="relative flex flex-wrap justify-center w-h-full">
+    <a href="#" class="flex h-full w-full items-center justify-center z-[1]">
+      <img src="/icon_img/guitar.svg" alt="guitar_icon" class="absolute w-1/2 p-1 drop-shadow">
+      <div class="bg-white rounded-full shadow-inner w-h-full"></div>
+    </a>
+    <p class="block mt-2 font-semibold joband-text-bk">GUITAR</p>
+  </div>
+<% end %>
+
+<% if instrument.name == "Drum" %>
+  <div class="relative flex flex-wrap justify-center w-h-full">
+    <a href="#" class="flex h-full w-full items-center justify-center z-[1]">
+      <img src="/icon_img/drum.svg" alt="drum_icon" class="absolute w-1/2 p-1 drop-shadow">
+      <div class="bg-white rounded-full shadow-inner w-h-full"></div>
+    </a>
+    <p class="block mt-2 font-semibold joband-text-bk">DRUM</p>
+  </div>
+<% end %>
+
+<% if instrument.name == "Bass" %>
+  <div class="relative flex flex-wrap justify-center w-h-full">
+    <a href="#" class="flex h-full w-full items-center justify-center z-[1]">
+      <img src="/icon_img/bass.svg" alt="bass_icon" class="absolute w-1/2 p-1 drop-shadow">
+      <div class="bg-white rounded-full shadow-inner w-h-full"></div>
+    </a>
+    <p class="block mt-2 font-semibold joband-text-bk">BASS</p>
+  </div>
+<% end %>
+
+<% if instrument.name == "Keyboard" %>
+  <div class="relative flex flex-wrap justify-center w-h-full">
+    <a href="#" class="flex h-full w-full items-center justify-center z-[1]">
+      <img src="/icon_img/keyboard.svg" alt="keyboard_icon" class="absolute w-1/2 p-1 drop-shadow">
+      <div class="bg-white rounded-full shadow-inner w-h-full"></div>
+    </a>
+    <p class="block mt-2 font-semibold joband-text-bk">KEYBOARD</p>
+  </div>
+<% end %>
+
+<% if instrument.name == "listener" %>
+  <div class="relative flex flex-wrap justify-center w-h-full">
+    <a href="#" class="flex items-center justify-center z-[1]">
+      <img src="/icon_img/listener.svg" alt="listener_icon" class="absolute w-1/2 p-1 drop-shadow">
+      <div class="block bg-white rounded-full shadow-inner w-h-full"></div>
+    </a>
+    <p class="block mt-2 font-semibold joband-text-bk">LISTENER</p>
+  </div>
+<% end %>


### PR DESCRIPTION
調整 profile CSS 以及創建樂團/修改 profile 按鈕的功能
整體頁面如下影片示範
https://youtu.be/Dyms9ifwvT4
頁面會顯示會的樂器以及所屬樂團
<img width="590" alt="image" src="https://github.com/astrocamp/14th-JoBand/assets/135109935/fdc10cfa-ede1-4c12-885e-e5f6d3bc3420">
<img width="715" alt="image" src="https://github.com/astrocamp/14th-JoBand/assets/135109935/76ce0aec-2cd7-4c72-a60b-2603d4ef43cd">
點樂團 icon 則是進到樂團的頁面

然後創建樂團與修改的按鈕若不是本人則不會顯示
這邊先把判斷式寫在頁面，還沒想到好命名，想到會搬到helper

