### PR TITLE
fix: 修復沒有創建資料的使用者，可以在nav看見 “創立樂團” 造成的錯誤

### DIFF
--- a/app/javascript/controllers/showband_controller.js
+++ b/app/javascript/controllers/showband_controller.js
@@ -12,7 +12,7 @@ export default class extends Controller {
     e.preventDefault();
     const displayStatus = this.my_bandTarget.style.display;
     if (displayStatus === "none") {
-      this.my_bandTarget.style.display = "inline";
+      this.my_bandTarget.style.display = "block";
     } else {
       this.my_bandTarget.style.display = "none";
     }

--- a/app/views/shared/_myband.html.erb
+++ b/app/views/shared/_myband.html.erb
@@ -1,5 +1,5 @@
 <% if user.bands.present? %>
-  <ul class="hidden" data-showband-target="my_band">
+  <ul class="block" data-showband-target="my_band">
     <% user.bands.each do |band| %>
       <li><%= link_to band.name, band_path(band) %></li>
     <% end %>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -11,38 +11,47 @@
     <ul class="flex gap-5">
       <% if user_signed_in? %>
         <li class="flex align-middle">
-          <div class="dropdown dropdown-hover dropdown-end">
-            <ul class="flex items-center mx-5 cursor-pointer">
-              <% if current_user.profile.present?%>
-                <li class="relative items-center w-10 joband-shadow">
-                  <%= render "shared/avatar", model: current_user.profile %>
-                </li>
-              </ul>
-              <ul class="p-2 shadow menu dropdown-content z-[1] bg-base-100 rounded-box w-52">
-                <li><%= link_to "個人檔案", profile_path(current_user.profile), class: "nav-link" %></li>
-              <% else %>
-                <li class="relative items-center w-10 joband-shadow">
-                  <img src="/default_avatar.png" alt="default_avatar" class="absolute w-full rounded-full" >
-                  <img src="/avatar_flame.svg" alt="avatar_flame" class="relative w-full h-full drop-shadow-2xl">
-                </li>
-              </ul>
-              <ul class="p-2 shadow menu dropdown-content z-[1] bg-base-100 rounded-box w-52">
-                <li><%= link_to "個人檔案", current_user.confirmed? ? letsjam_profiles_path : welcome_profiles_path, class: "nav-link" %></li>
-              <% end %>
-              <% if current_user&.bands.present? %>
-                <div data-controller="showband">
-                  <li><%= link_to "我的樂團", "#", class: "nav-link", data: { action:"click -> showband#show" } %></li>
-                  <div class="pl-2">
-                    <%= render "shared/myband", user: current_user %>
-                  </div>
-                </div>
-              <% else %>
-                <li><%= link_to "創建樂團", new_band_path, class: "nav-link" %></li>
-              <% end %>
-              <li><%= link_to "設定", edit_user_registration_path, class: "nav-link" %></li>
-              <li><%= link_to "登出", destroy_user_session_path,
-                              data: { turbo_method: 'delete' }, class: "nav-link" %></li>
-            </ul>
+          <div class="flex items-center mx-5 cursor-pointer dropdown dropdown-hover dropdown-bottom dropdown-end">
+            <% if current_user.profile.present?%>
+              <div tabindex="0" class="relative items-center w-10 joband-shadow">
+                <%= render "shared/avatar", model: current_user.profile %>
+              </div>
+                <ul tabindex="0" class="p-2 shadow menu dropdown-content z-[1] bg-base-100 rounded-box w-52">
+                  <li>
+                    <%= link_to "個人檔案", profile_path(current_user.profile), class: "nav-link" %>
+                  </li>
+                  <% if current_user&.bands.present? %>
+                    <div data-controller="showband">
+                      <li>
+                        <%= link_to "#", data: { action:"click -> showband#show" } do %>
+                          <div class="nav-link">我的樂團</div>
+                        <% end %>
+                      </li>
+                      <div class="pl-2">
+                        <%= render "shared/myband", user: current_user %>
+                      </div>
+                    </div>
+                  <% else %>
+                    <li>
+                      <%= link_to "創建樂團", new_band_path, class: "nav-link" %>
+                    </li>
+                  <% end %>
+            <% else %>
+              <div class="relative items-center w-10 joband-shadow">
+                <img src="/default_avatar.png" alt="default_avatar" class="absolute w-full rounded-full" >
+                <img src="/avatar_flame.svg" alt="avatar_flame" class="relative w-full h-full drop-shadow-2xl">
+              </div>
+                <ul class="p-2 shadow menu dropdown-content z-[1] bg-base-100 rounded-box w-52">
+                  <li>
+                    <%= link_to "個人檔案", current_user.confirmed? ? letsjam_profiles_path : welcome_profiles_path, class: "nav-link" %>
+                  </li>
+            <% end %>
+              <li>
+                <%= link_to "設定", edit_user_registration_path, class: "nav-link" %>
+              </li>
+              <li>
+                <%= link_to "登出", destroy_user_session_path, data: { turbo_method: 'delete' }, class: "nav-link" %>
+              </li>
           </div>
         </li>        
       <% else %>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -9,55 +9,56 @@
   </div>
   <div class="flex">
     <ul class="flex gap-5">
-      <% if user_signed_in? %>
-        <li class="flex align-middle">
-          <div class="flex items-center mx-5 cursor-pointer dropdown dropdown-hover dropdown-bottom dropdown-end">
-            <% if current_user.profile.present?%>
-              <div tabindex="0" class="relative items-center w-10 joband-shadow">
-                <%= render "shared/avatar", model: current_user.profile %>
-              </div>
-                <ul tabindex="0" class="p-2 shadow menu dropdown-content z-[1] bg-base-100 rounded-box w-52">
-                  <li>
-                    <%= link_to "個人檔案", profile_path(current_user.profile), class: "nav-link" %>
-                  </li>
-                  <% if current_user&.bands.present? %>
-                    <div data-controller="showband">
-                      <li>
-                        <%= link_to "#", data: { action:"click -> showband#show" } do %>
-                          <div class="nav-link">我的樂團</div>
-                        <% end %>
-                      </li>
-                      <div class="pl-2">
-                        <%= render "shared/myband", user: current_user %>
-                      </div>
-                    </div>
-                  <% else %>
-                    <li>
-                      <%= link_to "創建樂團", new_band_path, class: "nav-link" %>
-                    </li>
-                  <% end %>
-            <% else %>
-              <div class="relative items-center w-10 joband-shadow">
-                <img src="/default_avatar.png" alt="default_avatar" class="absolute w-full rounded-full" >
-                <img src="/avatar_flame.svg" alt="avatar_flame" class="relative w-full h-full drop-shadow-2xl">
-              </div>
-                <ul class="p-2 shadow menu dropdown-content z-[1] bg-base-100 rounded-box w-52">
-                  <li>
-                    <%= link_to "個人檔案", current_user.confirmed? ? letsjam_profiles_path : welcome_profiles_path, class: "nav-link" %>
-                  </li>
-            <% end %>
-              <li>
-                <%= link_to "設定", edit_user_registration_path, class: "nav-link" %>
-              </li>
-              <li>
-                <%= link_to "登出", destroy_user_session_path, data: { turbo_method: 'delete' }, class: "nav-link" %>
-              </li>
+    <% if user_signed_in? %>
+      <li class="flex align-middle">
+        <div class="flex items-center mx-5 cursor-pointer dropdown dropdown-hover dropdown-bottom dropdown-end">
+        <% if current_user.profile.present?%>
+          <div tabindex="0" class="relative items-center w-10 joband-shadow">
+            <%= render "shared/avatar", model: current_user.profile %>
           </div>
-        </li>        
-      <% else %>
-        <li><%= link_to "登入", new_user_session_path, class: "btn btn-ghost normal-case text-xl" %></li>
-        <li><%= link_to "註冊", new_user_registration_path, class: "btn btn-ghost normal-case text-xl" %></li>
-      <% end %>
+          <ul tabindex="0" class="p-2 shadow menu dropdown-content z-[1] bg-base-100 rounded-box w-52">
+            <li>
+              <%= link_to "個人檔案", profile_path(current_user.profile), class: "nav-link" %>
+            </li>
+            <% if current_user&.bands.present? %>
+            <div data-controller="showband">
+              <li>
+                <%= link_to "#", data: { action:"click -> showband#show" } do %>
+                  <div class="nav-link">我的樂團</div>
+                <% end %>
+              </li>
+              <div class="pl-2">
+                <%= render "shared/myband", user: current_user %>
+              </div>
+            </div>
+            <% else %>
+            <li>
+              <%= link_to "創建樂團", new_band_path, class: "nav-link" %>
+            </li>
+            <% end %>
+        <% else %>
+          <div class="relative items-center w-10 joband-shadow">
+            <img src="/default_avatar.png" alt="default_avatar" class="absolute w-full rounded-full" >
+            <img src="/avatar_flame.svg" alt="avatar_flame" class="relative w-full h-full drop-shadow-2xl">
+          </div>
+          <ul class="p-2 shadow menu dropdown-content z-[1] bg-base-100 rounded-box w-52">
+            <li>
+              <%= link_to "個人檔案", current_user.confirmed? ? letsjam_profiles_path : welcome_profiles_path, class: "nav-link" %>
+            </li>
+        <% end %>
+            <li>
+              <%= link_to "設定", edit_user_registration_path, class: "nav-link" %>
+            </li>
+            <li>
+              <%= link_to "登出", destroy_user_session_path, data: { turbo_method: 'delete' }, class: "nav-link" %>
+            </li>
+          </ul>
+        </div>
+      </li>        
+    <% else %>
+      <li><%= link_to "登入", new_user_session_path, class: "btn btn-ghost normal-case text-xl" %></li>
+      <li><%= link_to "註冊", new_user_registration_path, class: "btn btn-ghost normal-case text-xl" %></li>
+    <% end %>
     </ul>
   </div>
 </nav>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -13,10 +13,10 @@
       <li class="flex align-middle">
         <div class="flex items-center mx-5 cursor-pointer dropdown dropdown-hover dropdown-bottom dropdown-end">
         <% if current_user.profile.present?%>
-          <div tabindex="0" class="relative items-center w-10 joband-shadow">
+          <div class="relative items-center w-10 joband-shadow">
             <%= render "shared/avatar", model: current_user.profile %>
           </div>
-          <ul tabindex="0" class="p-2 shadow menu dropdown-content z-[1] bg-base-100 rounded-box w-52">
+          <ul class="p-2 shadow menu dropdown-content z-[1] bg-base-100 rounded-box w-52">
             <li>
               <%= link_to "個人檔案", profile_path(current_user.profile), class: "nav-link" %>
             </li>


### PR DESCRIPTION
- 本修復是用前端 nav 的方式拿掉選項而已，如果使用者改網址還是能進入創建
- 另外一併把 nav 判定的區域做了重建跟整理

### 待修復：
> band controller, 可能也要有驗證方式
#### 這裡不改動，因為可以討論是否要跟現在進行中的 Pundit 合併權限管理。


### 沒個人檔案的使用者，nav:
<img width="252" alt="截圖 2023-09-03 下午6 00 23" src="https://github.com/astrocamp/14th-JoBand/assets/128116961/a0b2718f-fbbe-474b-bb63-85ce1b0166c3">

### 有個人檔案的使用者，nav:
我的樂團改為預設開啟，並改為 display="block", 才不會跟線條重疊
<img width="258" alt="截圖 2023-09-03 下午6 00 09" src="https://github.com/astrocamp/14th-JoBand/assets/128116961/f12de868-d313-49d6-810a-ca8cab73359f">
