### PR TITLE
style: 增加friendly_id 讓band_id 在URL 改為樂團名

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'turbo-rails'
 gem "aws-sdk-s3", require: false
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 gem 'friendly_id', '~> 5.4.0'
+gem 'babosa'
 
 group :development, :test do
   gem 'byebug', '~> 11.1', '>= 11.1.3'

--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem 'tailwindcss-rails'
 gem 'turbo-rails'
 gem "aws-sdk-s3", require: false
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
+gem 'friendly_id', '~> 5.4.0'
 
 group :development, :test do
   gem 'byebug', '~> 11.1', '>= 11.1.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,6 +128,8 @@ GEM
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
     ffi (1.15.5)
+    friendly_id (5.4.2)
+      activerecord (>= 4.0.0)
     globalid (1.1.0)
       activesupport (>= 5.0)
     hashie (5.0.0)
@@ -345,6 +347,7 @@ DEPENDENCIES
   devise (~> 4.9)
   dotenv-rails
   faker!
+  friendly_id (~> 5.4.0)
   image_processing (~> 1.2)
   jbuilder
   jsbundling-rails (~> 1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,7 @@ GEM
       aws-sigv4 (~> 1.6)
     aws-sigv4 (1.6.0)
       aws-eventstream (~> 1, >= 1.0.2)
+    babosa (2.0.0)
     base64 (0.1.1)
     bcrypt (3.1.19)
     bindex (0.8.1)
@@ -341,6 +342,7 @@ PLATFORMS
 
 DEPENDENCIES
   aws-sdk-s3
+  babosa
   bootsnap
   byebug (~> 11.1, >= 11.1.3)
   capybara

--- a/app/controllers/bands_controller.rb
+++ b/app/controllers/bands_controller.rb
@@ -41,7 +41,7 @@ class BandsController < ApplicationController
   private
 
   def set_band
-    @band = Band.find(params[:id])
+    @band = Band.friendly.find(params[:slug])
   end
 
   def band_params

--- a/app/controllers/bands_controller.rb
+++ b/app/controllers/bands_controller.rb
@@ -24,7 +24,8 @@ class BandsController < ApplicationController
       @band.band_members.create(user: current_user, identity: :leader, role: @role)
       redirect_to band_path(@band), notice: '成功創立樂團'
     else
-      render :new, notice: '失敗'
+      flash.now[:alert] = '創建樂團失敗，樂團名稱重複。'
+      render :new
     end
   end
 

--- a/app/controllers/recruits_controller.rb
+++ b/app/controllers/recruits_controller.rb
@@ -41,7 +41,7 @@ class RecruitsController < ApplicationController
   private
 
   def set_band_id
-    @band = Band.find(params[:band_id])
+    @band = Band.friendly.find(params[:band_slug])
   end
 
   def set_recruit

--- a/app/models/band.rb
+++ b/app/models/band.rb
@@ -5,7 +5,7 @@ class Band < ApplicationRecord
   extend FriendlyId
   friendly_id :name, use: :slugged
 
-  validates :name, presence: true
+  validates :name, presence: true, uniqueness: true
 
   # associations
   has_rich_text :content

--- a/app/models/band.rb
+++ b/app/models/band.rb
@@ -4,7 +4,7 @@ class Band < ApplicationRecord
   #friendly_id
   extend FriendlyId
   friendly_id :name, use: :slugged
-  
+
   validates :name, presence: true
 
   # associations
@@ -40,5 +40,9 @@ class Band < ApplicationRecord
 
   def self.ransackable_associations(_auth_object = nil)
     %w[rich_text_content styles]
+  end
+
+  def normalize_friendly_id(input)
+    input.to_s.to_slug.normalize.to_s
   end
 end

--- a/app/models/band.rb
+++ b/app/models/band.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class Band < ApplicationRecord
+  #friendly_id
+  extend FriendlyId
+  friendly_id :name, use: :slugged
+  
   validates :name, presence: true
 
   # associations

--- a/app/views/bands/new.html.erb
+++ b/app/views/bands/new.html.erb
@@ -1,5 +1,11 @@
 <div class="flex flex-wrap justify-center w-11/12 h-auto mx-auto p-10 rounded-[50px] shadow-md bg-slate-100">
   <h1 class="w-full mb-5 text-2xl font-bold text-center joband-shadow joband-text-bk">創建樂團</h1>
+  <% if flash[:alert].present? %>
+  <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative" role="alert">
+    <strong class="font-bold">Error!</strong>
+    <span class="block sm:inline"><%= flash[:alert] %></span>
+  </div>
+<% end %>
   <div class="center">
       <%= render 'form', band: @band %>
   </div>

--- a/app/views/bands/new.html.erb
+++ b/app/views/bands/new.html.erb
@@ -1,12 +1,14 @@
 <div class="flex flex-wrap justify-center w-11/12 h-auto mx-auto p-10 rounded-[50px] shadow-md bg-slate-100">
   <h1 class="w-full mb-5 text-2xl font-bold text-center joband-shadow joband-text-bk">創建樂團</h1>
   <% if flash[:alert].present? %>
-  <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative" role="alert">
-    <strong class="font-bold">Error!</strong>
-    <span class="block sm:inline"><%= flash[:alert] %></span>
-  </div>
-<% end %>
+    <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative" role="alert">
+      <strong class="font-bold">Error!</strong>
+      <span class="block sm:inline"><%= flash[:alert] %></span>
+    </div>
+  <% end %>
   <div class="center">
-      <%= render 'form', band: @band %>
+    <%= render 'form', band: @band %>
   </div>
 </div>
+
+

--- a/config/initializers/friendly_id.rb
+++ b/config/initializers/friendly_id.rb
@@ -1,0 +1,107 @@
+# FriendlyId Global Configuration
+#
+# Use this to set up shared configuration options for your entire application.
+# Any of the configuration options shown here can also be applied to single
+# models by passing arguments to the `friendly_id` class method or defining
+# methods in your model.
+#
+# To learn more, check out the guide:
+#
+# http://norman.github.io/friendly_id/file.Guide.html
+
+FriendlyId.defaults do |config|
+  # ## Reserved Words
+  #
+  # Some words could conflict with Rails's routes when used as slugs, or are
+  # undesirable to allow as slugs. Edit this list as needed for your app.
+  config.use :reserved
+
+  config.reserved_words = %w(new edit index session login logout users admin
+    stylesheets assets javascripts images)
+    
+  # This adds an option to treat reserved words as conflicts rather than exceptions.
+  # When there is no good candidate, a UUID will be appended, matching the existing
+  # conflict behavior.
+
+  # config.treat_reserved_as_conflict = true
+
+  #  ## Friendly Finders
+  #
+  # Uncomment this to use friendly finders in all models. By default, if
+  # you wish to find a record by its friendly id, you must do:
+  #
+  #    MyModel.friendly.find('foo')
+  #
+  # If you uncomment this, you can do:
+  #
+  #    MyModel.find('foo')
+  #
+  # This is significantly more convenient but may not be appropriate for
+  # all applications, so you must explicity opt-in to this behavior. You can
+  # always also configure it on a per-model basis if you prefer.
+  #
+  # Something else to consider is that using the :finders addon boosts
+  # performance because it will avoid Rails-internal code that makes runtime
+  # calls to `Module.extend`.
+  #
+  # config.use :finders
+  #
+  # ## Slugs
+  #
+  # Most applications will use the :slugged module everywhere. If you wish
+  # to do so, uncomment the following line.
+  #
+  # config.use :slugged
+  #
+  # By default, FriendlyId's :slugged addon expects the slug column to be named
+  # 'slug', but you can change it if you wish.
+  #
+  # config.slug_column = 'slug'
+  #
+  # By default, slug has no size limit, but you can change it if you wish.
+  #
+  # config.slug_limit = 255
+  #
+  # When FriendlyId can not generate a unique ID from your base method, it appends
+  # a UUID, separated by a single dash. You can configure the character used as the
+  # separator. If you're upgrading from FriendlyId 4, you may wish to replace this
+  # with two dashes.
+  #
+  # config.sequence_separator = '-'
+  #
+  # Note that you must use the :slugged addon **prior** to the line which
+  # configures the sequence separator, or else FriendlyId will raise an undefined
+  # method error.
+  #
+  #  ## Tips and Tricks
+  #
+  #  ### Controlling when slugs are generated
+  #
+  # As of FriendlyId 5.0, new slugs are generated only when the slug field is
+  # nil, but if you're using a column as your base method can change this
+  # behavior by overriding the `should_generate_new_friendly_id?` method that
+  # FriendlyId adds to your model. The change below makes FriendlyId 5.0 behave
+  # more like 4.0.
+  # Note: Use(include) Slugged module in the config if using the anonymous module.
+  # If you have `friendly_id :name, use: slugged` in the model, Slugged module
+  # is included after the anonymous module defined in the initializer, so it
+  # overrides the `should_generate_new_friendly_id?` method from the anonymous module.
+  #
+  # config.use :slugged
+  # config.use Module.new {
+  #   def should_generate_new_friendly_id?
+  #     slug.blank? || <your_column_name_here>_changed?
+  #   end
+  # }
+  #
+  # FriendlyId uses Rails's `parameterize` method to generate slugs, but for
+  # languages that don't use the Roman alphabet, that's not usually sufficient.
+  # Here we use the Babosa library to transliterate Russian Cyrillic slugs to
+  # ASCII. If you use this, don't forget to add "babosa" to your Gemfile.
+  #
+  # config.use Module.new {
+  #   def normalize_friendly_id(text)
+  #     text.to_slug.normalize! :transliterations => [:russian, :latin]
+  #   end
+  # }
+end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-workers ENV.fetch("WEB_CONCURRENCY") { 2 }
 max_threads_count = ENV.fetch('RAILS_MAX_THREADS', 5)
 min_threads_count = ENV.fetch('RAILS_MIN_THREADS') { max_threads_count }
 threads min_threads_count, max_threads_count

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,7 @@ Rails.application.routes.draw do
 
   resources :activities
 
-  resources :bands, except: [:destroy] do
+  resources :bands, param: :slug, except: [:destroy] do
     resources :band_members, except: %i[new show index]
     resources :recruits, shallow: true do
       resources :resume_lists, except: %i[destroy index] do

--- a/db/migrate/20230904072539_add_slug_to_bands.rb
+++ b/db/migrate/20230904072539_add_slug_to_bands.rb
@@ -1,0 +1,6 @@
+class AddSlugToBands < ActiveRecord::Migration[7.0]
+  def change
+    add_column :bands, :slug, :string
+    add_index :bands, :slug, unique: true
+  end
+end

--- a/db/migrate/20230904072633_create_friendly_id_slugs.rb
+++ b/db/migrate/20230904072633_create_friendly_id_slugs.rb
@@ -1,0 +1,21 @@
+MIGRATION_CLASS =
+  if ActiveRecord::VERSION::MAJOR >= 5
+    ActiveRecord::Migration["#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}"]
+  else
+    ActiveRecord::Migration
+  end
+
+class CreateFriendlyIdSlugs < MIGRATION_CLASS
+  def change
+    create_table :friendly_id_slugs do |t|
+      t.string   :slug,           :null => false
+      t.integer  :sluggable_id,   :null => false
+      t.string   :sluggable_type, :limit => 50
+      t.string   :scope
+      t.datetime :created_at
+    end
+    add_index :friendly_id_slugs, [:sluggable_type, :sluggable_id]
+    add_index :friendly_id_slugs, [:slug, :sluggable_type], length: { slug: 140, sluggable_type: 50 }
+    add_index :friendly_id_slugs, [:slug, :sluggable_type, :scope], length: { slug: 70, sluggable_type: 50, scope: 70 }, unique: true
+  end
+end


### PR DESCRIPTION
1. 加入friendly_id 讓網址上原本的band_id 改為 樂團名(中英文都有)
2. 增加band.rb的validates 讓樂團名不能重複取名
3. 招募的controller 也把band_id 改為band_slug，才不會按下建立招募時跑到404頁面
4. 等之後活動建立關聯性後，會再更改活動的部分

英文
<img width="955" alt="截圖 2023-09-04 下午4 07 53" src="https://github.com/astrocamp/14th-JoBand/assets/140575755/1243eef9-a869-4116-ba97-3fbe0b21d9de">

中文
<img width="996" alt="截圖 2023-09-04 下午4 06 43" src="https://github.com/astrocamp/14th-JoBand/assets/140575755/28a12a56-c7df-4bd6-9886-977a96df55c3">
