### PR TITLE
style: 更改通知數量為紅點

### DIFF
--- a/app/notifications/resume_list_notification.rb
+++ b/app/notifications/resume_list_notification.rb
@@ -22,7 +22,7 @@ class ResumeListNotification < Noticed::Base
   end
 
   def url
-    recruit_path(params[:band].recruit)
+    resume_list_path(params[:band].recruit)
   end
   # def url
   #   band_path(Band.find(params[:resume_list][:band_slug]))

--- a/app/views/shared/_notifications.html.erb
+++ b/app/views/shared/_notifications.html.erb
@@ -6,13 +6,14 @@
           <%= image_tag "icon/bell.svg", width: "30", height: "30" %>
           <% if @unread.count > 0 %>
             <div class="absolute top-0 right-[-5px] bg-red-500 text-white rounded-full w-5 h-5 flex items-center justify-center text-sm font-semibold">
-              <%= @unread.count >= 9 ? "9+" : @unread.count %>
+              <!-- 使用紅點代替數字，如果沒有未讀通知則不顯示紅點 -->
+              <%= content_tag(:div, '', class: 'red-dot') %>
             </div>
           <% end %>
         </div>
       </summary>
       <ul class="p-2 shadow menu dropdown-content z-[1] bg-base-100 rounded-box w-52">
-        <% @unread.each do |notification| %>
+        <% @unread.take(5).each do |notification| %>
           <%= render 'shared/notification', notification: notification %>
         <% end %>
         <% if @read.count > 0 && @unread.count > 0 %>
@@ -31,7 +32,5 @@
     </details>
   </li>
 <% end %>
-
-
 
 


### PR DESCRIPTION
1.把通知數量改為紅點
2.點擊通知連結會直接到申請者的頁面
3.要跟大家討論，目前我本地JS無法正常作動，所以看有沒有人要接著做點擊通知後可以清除通知或是讓通知紅點消失，有新通知才顯示紅點，時間上如果來不及就先維持目前的現狀

目前把通知改為沒有時不會顯示：
<img width="1437" alt="截圖 2023-09-12 下午7 05 54" src="https://github.com/astrocamp/14th-JoBand/assets/140575755/72f66369-c69c-449d-a81d-a27625f3e404">

有通知時會有紅點：
<img width="1440" alt="截圖 2023-09-12 下午7 06 21" src="https://github.com/astrocamp/14th-JoBand/assets/140575755/c3cc27f1-a36c-44f5-afd8-d197c9683250">
