### PR TITLE
fix: 修正 devise 亂碼錯誤訊息, 並且改用 flash 顯示

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,6 @@ class User < ApplicationRecord
          :omniauthable, omniauth_providers: %i[google_oauth2]
 
   # validates
-  validates :password, presence: true, length: { in: 8..16 }
   validates :email, presence: true, format: { with: Devise.email_regexp }
 
   # associations

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -1,30 +1,31 @@
-<div class="bg-dark rounded-md px-10 py-5 flex-wrap w-60%">
-  <header class="block w-100% text-white">
-    <h2 class="h2"><%= t("user.change_your_password")%></h2>
+<div class="px-5 py-5 mx-auto mt-10 bg-white rounded-lg joband-shadow flex-warp theme-text w-fit">
+  <header class="block font-bold text-center">
+    <h2 class="h2 joband-text-bk"><%= t("user.change_your_password")%></h2>
   </header>
+  <div class="card-body">
+    <div class="block mx-auto w-fit">
+      <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+        <%= render "users/shared/error_messages", resource: resource, class: "font-bold joband-text-bk" %>
+        <%= f.hidden_field :reset_password_token %>
 
-  <div class="block mx-auto w-100%">
-    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-      <%= render "users/shared/error_messages", resource: resource %>
-      <%= f.hidden_field :reset_password_token %>
+        <div class="my-3 field">
+          <%= f.label :password, t("user.new_password"), class: "font-bold joband-text-bk" %><br />
+          <%= f.password_field :password, autofocus: true, autocomplete: "new-password", placeholder: t("user.min_password_placeholder"), class: "input input-bordered mb-3" %>
+        </div>
 
-      <div class="my-2 field">
-        <%= f.label :password, t("user.new_password"), class: "text-white" %><br />
-        <%= f.password_field :password, autofocus: true, autocomplete: "new-password", placeholder: t("user.min_password_placeholder") %>
-      </div>
+        <div class="my-3 field">
+          <%= f.label :password_confirmation, t("user.confirm_new_password"), class: "font-bold joband-text-bk" %><br />
+          <%= f.password_field :password_confirmation, autocomplete: "new-password", placeholder: t("user.password_confirmation_placeholder"), class: "input input-bordered mb-3" %>
+        </div>
 
-      <div class="my-2 field">
-        <%= f.label :password_confirmation, t("user.confirm_new_password"), class: "text-white" %><br />
-        <%= f.password_field :password_confirmation, autocomplete: "new-password", placeholder: t("user.password_confirmation_placeholder") %>
-      </div>
+        <div class="mt-5 form-control">
+          <%= f.submit t("user.change_your_password"), class: "joband-action-btn" %>
+        </div>
+      <% end %>
+    </div>
 
-      <div class="actions">
-        <%= f.submit t("user.change_your_password"), class: "btn" %>
-      </div>
-    <% end %>
-  </div>
-
-  <div class="text-white aside-info">
-    <%= render "users/shared/links" %>
+    <div class="my-3 form-control">
+      <%= render "users/shared/links" %>
+    </div>
   </div>
 </div>

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -6,9 +6,9 @@
     <div class="flex flex-wrap justify-center w-full mb-5 field">
       <input type="text" placeholder="<%= @current_user.email %>" class="w-full max-w-xs input input-bordered" disabled /><br/>
       <% if current_user.confirmed? %>
-        <span class="w-full my-2 text-center text-lime-400"> Email 已驗證</span>
+        <span class="w-full my-2 font-bold text-center text-lime-400"> Email 已驗證</span>
       <% else %>  
-        <span class="w-full my-2 text-center text-orange-400"> Email 尚未驗證</span><br/>
+        <span class="w-full my-2 font-bold text-center text-orange-400"> Email 尚未驗證</span><br/>
         <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
           <%= link_to t("user.not_receive_confirm"), new_confirmation_path(resource_name), class: "link" %><br />
         <% end %>
@@ -18,8 +18,8 @@
       <%= render "users/shared/error_messages", resource: resource %>
 
       <div class="mb-5 field">
-        <%= f.label :name, t("user.display_name"),class: "text-white" %><br />
-        <%= f.text_field :name, autofocus: true, autocomplete: :off, class: "joband-ring-offset rounded-xl input-md input-bordered w-full max-w-xs" %>
+        <%= f.label :name, t("user.display_name"),class: "joband-text-bk font-bold" %><br />
+        <%= f.text_field :name, autofocus: true, autocomplete: :off, class: "focus:joband-ring-offset rounded-xl input-md input-bordered w-full max-w-xs py-3" %>
       </div>
 
       <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
@@ -27,23 +27,25 @@
       <% end %>
 
       <div class="mb-5 field">
-        <%= f.label :password, t("user.new_password"), class: "text-white" %> <br />
-        <%= f.password_field :password, placeholder: t("user.min_password_placeholder"),autocomplete: "new-password", class: "joband-ring-offset rounded-xl input-md input-bordered w-full max-w-xs" %>
-        <br /><i class="block my-2 joband-text-bk"><%= t("user.leave_blank") %></i>
+        <%= f.label :password, t("user.new_password"), class: "label-text joband-text-bk font-bold" %> <br />
+        <%= f.password_field :password, placeholder: t("user.min_password_placeholder"),autocomplete: "new-password", class: "focus:joband-ring-offset rounded-xl input-md input-bordered w-full max-w-xs" %>
+        <br /><i class="block my-2 text-sm joband-text-bk"><%= t("user.leave_blank") %></i>
       </div>
 
       <div class="mb-5 field">
-        <%= f.label :password_confirmation, t("user.password_confirmation"), class: "text-white" %><br />
-        <%= f.password_field :password_confirmation, placeholder: t("user.password_confirmation_placeholder"), autocomplete: "new-password", class: "joband-ring-offset rounded-xl input-md input-bordered w-full max-w-xs" %>
+        <%= f.label :password_confirmation, t("user.password_confirmation"), class: "label-text joband-text-bk font-bold" %><br />
+        <%= f.password_field :password_confirmation, placeholder: t("user.password_confirmation_placeholder"), autocomplete: "new-password", class: "focus:joband-ring-offset rounded-xl input-md input-bordered w-full max-w-xs" %>
       </div>
 
       <div class="mb-5 field">
-        <%= f.label :current_password, t("user.current_password"), class: "text-white" %><br />
-        <%= f.password_field :current_password, autocomplete: "current-password", class: "joband-ring-offset rounded-xl input-md input-bordered w-full max-w-xs" %>
+        <%= f.label :current_password, t("user.current_password"), class: "label-text joband-text-bk font-bold" %><br />
+        <%= f.password_field :current_password, autocomplete: "current-password", class: "focus:joband-ring-offset rounded-xl input-md input-bordered w-full max-w-xs" %>
         <br /><i class="block my-2 joband-text-bk"><%= t("user.need_current_password") %></i>
       </div>
+        <%= link_to t("user.forgot_password"), new_password_path(resource_name), class: "link joband-text-bk" %><br />
       <div class="flex justify-center w-full">
-        <%= f.submit t("user.update"), class: "joband-action-btn" %>
+        <%= f.submit t("user.update"), class: "joband-hover-style my-5" %>
+        <%= button_to "返回", root_path, class: "ml-auto joband-reject-btn my-5" %>
       </div>
     <% end %>
   </div>

--- a/app/views/users/shared/_error_messages.html.erb
+++ b/app/views/users/shared/_error_messages.html.erb
@@ -1,8 +1,8 @@
 <% if resource.errors.any? %>
-  <div id="error_explanation" data-turbo-cache="false">
+  <div id="error_explanation" data-turbo-cache="false", class="font-bold joband-text-bk">
     <ul>
       <% resource.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
+        <li><% flash.now[:alert] = message %></li>
       <% end %>
     </ul>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -9,17 +9,22 @@ en:
               too_long: "is too long"
             password_confirmation:
               confirmation: "does not match"
+            current_password:
+              blank: "can't be blank"
+              invalid: "does not match, please try again"
             email:
               taken: "has been taken"
         band:
           attributes:
             name:
-              blank: "Cant Be Blank "
+              blank: "Can't Be Blank "
               taken: "Has Been taken"
+
     attributes:
       user:
         password: "Password"
         password_confirmation: "Password confirmation"
+      current_password: "Current password"
 
   notifications:
     resume_list_notification:

--- a/config/locales/tw.yml
+++ b/config/locales/tw.yml
@@ -9,6 +9,9 @@ tw:
               too_long: "多過 16 個字元"
             password_confirmation:
               confirmation: "有誤，請再試一次！"
+            current_password:
+              blank: "不能為空"
+              invalid: "有誤，請再試一次"
             email:
               taken: "已被註冊"
         band:
@@ -16,13 +19,15 @@ tw:
             name:
               blank: 不能為空
               taken: 已被使用
-      
+
     attributes:
       user:
         password: "密碼"
         password_confirmation: 確認密碼欄位
+        current_password: 現有密碼
       band:
         name: 樂團名稱
+
   notifications:
     resume_list_notification:
       message: "您有新的招募申請"


### PR DESCRIPTION
一勞永逸解決了 devise 奇怪的錯誤訊息，且全部轉用 flash 顯示
並且在設定頁面，增加忘記密碼選項，方便第三方登入者，去更改密碼

順道修了幾個CSS頁面
<img width="1184" alt="截圖 2023-09-13 上午12 46 18" src="https://github.com/astrocamp/14th-JoBand/assets/128116961/615e45d3-8b4b-4193-8892-055ca765aff4">
<img width="432" alt="截圖 2023-09-13 上午12 45 46" src="https://github.com/astrocamp/14th-JoBand/assets/128116961/b67403d1-ea73-440d-b5f9-a8f9819279aa">
