### PR TITLE
fix:修正討論區點選留言者的profile時會出現content missing的問題

### DIFF
--- a/app/views/comments/_comment_activity.html.erb
+++ b/app/views/comments/_comment_activity.html.erb
@@ -4,7 +4,7 @@
       <div class="w-[50px] h-[50px] relative mr-2">
         <%= render "shared/avatar", model: comment.user.profile %>
       </div>
-      <%= link_to comment.user.name, profile_path(comment.user_id), class: "font-semibold"%>
+      <%= link_to comment.user.name, profile_path(comment.user_id), target: "_blank", class: "font-semibold"%>
     </div>
     <div class='p-3 my-1 text-left break-words h4'>
       <p><%= comment.content %></p>

--- a/app/views/comments/_comment_activity.html.erb
+++ b/app/views/comments/_comment_activity.html.erb
@@ -4,9 +4,9 @@
       <div class="w-[50px] h-[50px] relative mr-2">
         <%= render "shared/avatar", model: comment.user.profile %>
       </div>
-      <%= link_to comment.user.name, profile_path(comment.user_id), target: "_blank", class: "font-semibold"%>
+      <%= link_to comment.user.name, profile_path(comment.user_id), target: "_blank", class: "font-bold"%>
     </div>
-    <div class='p-3 my-1 text-left break-words h4'>
+    <div class='p-3 my-1 text-left break-words'>
       <p><%= comment.content %></p>
     </div>
     <div class='flex flex-row-reverse mt-2 mb-2 text-base'>

--- a/app/views/comments/_comment_post.html.erb
+++ b/app/views/comments/_comment_post.html.erb
@@ -3,7 +3,7 @@
 
     <% comments.each do |comment| %>
     <div class='border-b w-full max-w-md my-2'>
-        <div class='text-left break-words'>
+        <div class='text-left font-bold'>
         <%= link_to comment.user.name, profile_path(comment.user_id), target: "_blank"%>:
         </div>
         <div class='text-left my-1 break-words'>

--- a/app/views/comments/_comment_post.html.erb
+++ b/app/views/comments/_comment_post.html.erb
@@ -13,6 +13,7 @@
         [<%= comment.created_at.strftime('%Y-%m-%d %H:%M') %>]
         <% if comment.user == current_user %>
         <%= link_to '刪除', comment_path(comment, post_id: post.id),
+                            class:'text-sm text-red-400',
                             data: {turbo_method: 'delete',
                             turbo_confirm: '確定刪除？'
                                 } %>

--- a/app/views/comments/_comment_post.html.erb
+++ b/app/views/comments/_comment_post.html.erb
@@ -4,7 +4,7 @@
     <% comments.each do |comment| %>
     <div class='border-b w-full max-w-md my-2'>
         <div class='text-left break-words'>
-        <%= link_to comment.user.name, profile_path(comment.user_id)%>:
+        <%= link_to comment.user.name, profile_path(comment.user_id), target: "_blank"%>:
         </div>
         <div class='text-left my-1 break-words'>
         <p><%= comment.content %></p>

--- a/app/views/comments/_comment_resume.html.erb
+++ b/app/views/comments/_comment_resume.html.erb
@@ -3,7 +3,7 @@
   <% comments.each do |comment| %>
     <li>
       <div>
-        <%= link_to comment.user.name, profile_path(comment.user_id), 
+        <%= link_to comment.user.name, profile_path(comment.user_id), target: "_blank", 
                                       class:'text-sky-400 border-b border-sky-400' %>
       </div>
       <div class="m-3 joband-text-bk">

--- a/app/views/comments/_comment_resume.html.erb
+++ b/app/views/comments/_comment_resume.html.erb
@@ -12,7 +12,7 @@
       <div class="flex justify-end">
         <% if comment.user == current_user %>
          <%= link_to '刪除', comment_path(comment, resume_list_id: resume_list.id),
-                            class:'text-xs text-red-400',
+                            class:'text-sm text-red-400',
                             data: {
                               turbo_method: 'delete',
                               turbo_confirm: '確定刪除？'
@@ -20,7 +20,7 @@
         <% end %>
       </div>
 
-      <div class="text-xs mb-1 joband-text-bk">
+      <div class="text-sm mb-1 joband-text-bk">
         (<%= comment.created_at.strftime('%Y-%m-%d %H:%M') %>)
       </div>
 

--- a/app/views/comments/_comment_resume.html.erb
+++ b/app/views/comments/_comment_resume.html.erb
@@ -4,9 +4,9 @@
     <li>
       <div>
         <%= link_to comment.user.name, profile_path(comment.user_id), target: "_blank", 
-                                      class:'text-sky-400 border-b border-sky-400' %>
+                                      class:'font-bold' %>
       </div>
-      <div class="m-3 joband-text-bk">
+      <div class="m-3 break-words">
         <%= comment.content %>
       </div>
       <div class="flex justify-end">

--- a/app/views/posts/_posts.html.erb
+++ b/app/views/posts/_posts.html.erb
@@ -4,13 +4,9 @@
       <%= post_avatar(post.user.profile) %>
     </div>
     <div class="justify-between flex-auto">
-      <%= link_to post.user.name, profile_path(post.user), class: "hover:underline font-bold", data: {turbo: false} %>
+      <%= link_to post.user.name, profile_path(post.user), class: "hover:underline font-bold", data: {turbo: false} , target: "_blank"%>
       <em class="inline-block pr-10 text-xs text-end"><%= post.created_at.strftime('%m/%d %H:%M') %></em>
-    
-      <%= link_to post, data: {turbo: false} do %>
-        <div class="prose prose-lg"><%= post.body %></div>
-      <% end %>
-
+    <div class="prose prose-lg"><%= post.body %></div>
       <%= render "posts/controls", post: post %>
 
       <div class="pl-2" data-comments-target="content" data-link-id="<%= post.id %>" style="display: none;">


### PR DESCRIPTION
由於討論區點選留言者的profile時會出現content missing的問題,應該是turbo的關係,如用新視窗去開始留言者的profile則沒有問題
<img width="798" alt="image" src="https://github.com/astrocamp/14th-JoBand/assets/130462029/4d16ef38-d014-4ad0-9ea7-bd3e491d0ff6">

因此更改為點選後開啟新視窗,另外維持統一性的關係除了討論區,活動跟招募的留言區一樣修改為新開視窗
另外討論區無Show頁面的關係,因此移除討論串上的Link