### PR TITLE
Fix: 留言的連結錯誤

### DIFF
--- a/app/views/bands/_form.html.erb
+++ b/app/views/bands/_form.html.erb
@@ -1,8 +1,8 @@
 <div class="center flex-wrap w-full lg:w-[60%] h-auto mx-auto p-10 lg:rounded-[80px] joband-shadow bg-white">
   <div class="text-base center joband-text-bk">
     <%= form_with(model: band , data:{ turbo: false }, class: "center flex-wrap" ) do |f| %>
-    
-      <%= render "users/shared/error_messages", resource: band %>
+
+      <%= render "error_messages", resource: band %>
 
       <div class="flex flex-wrap items-center my-5 w-[90%]">
         <%= f.label :name, class: "w-full mb-3 lg:w-[120px] block" %>

--- a/app/views/bands/_form.html.erb
+++ b/app/views/bands/_form.html.erb
@@ -1,11 +1,12 @@
 <div class="center flex-wrap w-full lg:w-[60%] h-auto mx-auto p-10 lg:rounded-[80px] joband-shadow bg-white">
   <div class="text-base center joband-text-bk">
     <%= form_with(model: band , data:{ turbo: false }, class: "center flex-wrap" ) do |f| %>
+    
       <%= render "users/shared/error_messages", resource: band %>
 
       <div class="flex flex-wrap items-center my-5 w-[90%]">
         <%= f.label :name, class: "w-full mb-3 lg:w-[120px] block" %>
-        <%= f.text_field :name, maxlength: 10, placeholder: "請輸入 10 字以內的團名",  required: true, class: "joband-ring-offset rounded-xl input-md input-bordered lg:w-1/2 w-full"%>
+        <%= f.text_field :name, maxlength: 10, placeholder: "請輸入 10 字以內的團名",  required: true, class: " joband-ring-offset rounded-xl input-md input-bordered lg:w-[10em] w-[10em]"%>
       </div>
       
       <% if action_name.in?(['new', 'create']) %>

--- a/app/views/comments/_comment_activity.html.erb
+++ b/app/views/comments/_comment_activity.html.erb
@@ -4,7 +4,11 @@
       <div class="w-[50px] h-[50px] relative mr-2">
         <%= render "shared/avatar", model: comment.user.profile %>
       </div>
-      <%= link_to comment.user.name, profile_path(comment.user_id), target: "_top", class: "font-bold"%>
+      <% if comment.user&.profile.present? %>
+        <%= link_to comment.user.name, profile_path(comment.user.profile.id),class: "font-bold", target: "_top"%>:
+      <% else %>
+        <%= comment.user.name %>
+      <% end %>
     </div>
     <div class='p-3 my-1 text-left break-words'>
       <p><%= comment.content %></p>

--- a/app/views/comments/_comment_activity.html.erb
+++ b/app/views/comments/_comment_activity.html.erb
@@ -2,12 +2,21 @@
   <li class='w-[60%] p-5 my-2 border-b rounded-3xl bg-slate-100 sm:w-[95%]'>
     <div class='flex joband-text-bk h4'>
       <div class="w-[50px] h-[50px] relative mr-2">
-        <%= render "shared/avatar", model: comment.user.profile %>
+        <% if comment.user&.profile.present? %>
+          <%= render "shared/avatar", model: comment.user.profile %>
+        <% else %>
+          <img src="/default_avatar.png" alt="default_avatar" class="absolute w-full rounded-full joband-shadow" >
+          <img src="/avatar_flame.svg" alt="avatar_flame" class="relative w-full h-full">
+        <% end %>
       </div>
+      
       <% if comment.user&.profile.present? %>
-        <%= link_to comment.user.name, profile_path(comment.user.profile.id),class: "font-bold", target: "_top"%>:
+        <%= link_to comment.user.name, profile_path(comment.user.profile.id),class: "flex items-center font-bold", target: "_top"%>
       <% else %>
+      <p class="flex items-center">
         <%= comment.user.name %>
+      </p>
+        
       <% end %>
     </div>
     <div class='p-3 my-1 text-left break-words'>

--- a/app/views/comments/_comment_post.html.erb
+++ b/app/views/comments/_comment_post.html.erb
@@ -3,12 +3,24 @@
 
     <% comments.each do |comment| %>
     <div class='border-b w-full max-w-md my-2'>
-        <div class='text-left font-bold'>
-          <% if comment.user&.profile.present? %>
-            <%= link_to comment.user.name, profile_path(comment.user.profile.id), target: "_top"%>:
-          <% else %>
+        <div class='flex joband-text-bk h4'>
+
+          <div class="w-[50px] h-[50px] relative mr-2">
+            <% if comment.user&.profile.present? %>
+              <%= render "shared/avatar", model: comment.user.profile %>
+            <% else %>
+              <img src="/default_avatar.png" alt="default_avatar" class="absolute w-full rounded-full joband-shadow" >
+              <img src="/avatar_flame.svg" alt="avatar_flame" class="relative w-full h-full">
+            <% end %>
+          </div>
+
+        <% if comment.user&.profile.present? %>
+          <%= link_to comment.user.name, profile_path(comment.user.profile.id),class: "theme-text flex items-center font-bold", target: "_top"%>
+        <% else %>
+          <p class="flex items-center theme-text">
             <%= comment.user.name %>
-          <% end %>
+          </p>
+        <% end %>
         </div>
         <div class='text-left my-1 break-words'>
         <p><%= comment.content %></p>

--- a/app/views/comments/_comment_post.html.erb
+++ b/app/views/comments/_comment_post.html.erb
@@ -4,7 +4,11 @@
     <% comments.each do |comment| %>
     <div class='border-b w-full max-w-md my-2'>
         <div class='text-left font-bold'>
-        <%= link_to comment.user.name, profile_path(comment.user_id), target: "_top"%>:
+          <% if comment.user&.profile.present? %>
+            <%= link_to comment.user.name, profile_path(comment.user.profile.id), target: "_top"%>:
+          <% else %>
+            <%= comment.user.name %>
+          <% end %>
         </div>
         <div class='text-left my-1 break-words'>
         <p><%= comment.content %></p>

--- a/app/views/comments/_comment_resume.html.erb
+++ b/app/views/comments/_comment_resume.html.erb
@@ -3,8 +3,11 @@
   <% comments.each do |comment| %>
     <li>
       <div>
-        <%= link_to comment.user.name, profile_path(comment.user_id), target: "_top", 
-                                      class:'font-bold' %>
+        <% if comment.user&.profile.present? %>
+          <%= link_to comment.user.name, profile_path(comment.user.profile.id), target: "_top"%>:
+        <% else %>
+          <%= comment.user.name %>
+        <% end %>
       </div>
       <div class="m-3 break-words">
         <%= comment.content %>


### PR DESCRIPTION
留言的連結會去 profile , 但是連結的 參數 是user_id , 
所以如果有 profile 跳號的問題, 就會連錯人 , 
但寫 comment.user.profile.id 的話 , 沒有 profile 的人留言整頁就會爆炸, 
所以判斷 , 如果你沒有profile 的話 , 就直接 render name 