### PR TITLE
fix: posts profile link error

### DIFF
--- a/app/views/posts/_posts.html.erb
+++ b/app/views/posts/_posts.html.erb
@@ -6,7 +6,7 @@
     <div class="justify-between w-10/12">
       <%= link_to post.user.name, profile_path(post.user.profile), class: "hover:underline font-bold mr-2", data: {turbo: false} , target: "_top"%>
       <em class="inline-block pr-10 text-xs text-end joband-text-em"><%= post.created_at.strftime('%m/%d %H:%M') %></em>
-      <div class="my-2 break-words"><p><%= post.body %></p></div>s
+      <div class="my-2 break-words"><p><%= post.body %></p></div>
       <%= render "posts/controls", post: post %>
 
       <div class="pl-2" data-comments-target="content" data-link-id="<%= post.id %>" style="display: none;">

--- a/app/views/posts/_posts.html.erb
+++ b/app/views/posts/_posts.html.erb
@@ -4,9 +4,9 @@
       <%= render "shared/avatar", model: post.user.profile %>
     </div>
     <div class="justify-between w-10/12">
-      <%= link_to post.user.name, profile_path(post.user), class: "hover:underline font-bold mr-2", data: {turbo: false} , target: "_top"%>
+      <%= link_to post.user.name, profile_path(post.user.profile), class: "hover:underline font-bold mr-2", data: {turbo: false} , target: "_top"%>
       <em class="inline-block pr-10 text-xs text-end joband-text-em"><%= post.created_at.strftime('%m/%d %H:%M') %></em>
-      <div class="my-2 break-words"><p><%= post.body %></p></div>
+      <div class="my-2 break-words"><p><%= post.body %></p></div>s
       <%= render "posts/controls", post: post %>
 
       <div class="pl-2" data-comments-target="content" data-link-id="<%= post.id %>" style="display: none;">


### PR DESCRIPTION
修改了討論區 PO 文時候 user.name 的連結會有404的狀況 ( 因為 profile.id 與 post.user.id 有可能跳號 )

原本 post.user 更改為 post.user.profile 就可以抓到該 user 的 profile